### PR TITLE
FISH-8052 Incorrect Payara Platform version sequence in Payara Starter Application Generator

### DIFF
--- a/starter-ui/src/main/java/fish/payara/starter/resources/VersionResource.java
+++ b/starter-ui/src/main/java/fish/payara/starter/resources/VersionResource.java
@@ -40,8 +40,8 @@ public class VersionResource {
             List<String> versions = extractVersions(versionData)
                     .stream()
                     .filter(version -> !version.contains("Alpha") && !version.contains("Beta"))
-                    .sorted(Collections.reverseOrder())
                     .collect(Collectors.toList());
+            Collections.reverse(versions);
             lastFetchedTime = System.currentTimeMillis();
             cachedVersions = versions;
         }


### PR DESCRIPTION
Fixes incorrect sorting of Payara Platform version:

![image](https://github.com/payara/ecosystem-starter/assets/15934072/0375779f-7191-4ec1-8b0f-43aa86a2d1cd)
