### PR TITLE
FISH-8053 Disable the Jakarta EE Core Profile for EE versions lower than 10

### DIFF
--- a/starter-ui/src/main/webapp/assets/main.js
+++ b/starter-ui/src/main/webapp/assets/main.js
@@ -257,3 +257,39 @@ mpFaultTolerance.addEventListener('change', function () {
 mpMetrics.addEventListener('change', function () {
     selectAllMP.checked = mpConfig.checked && mpOpenAPI.checked && mpFaultTolerance.checked && mpMetrics.checked;
 });
+
+const platformRadioButton = document.getElementById('full');
+const webRadioButton = document.getElementById('web');
+const coreRadioButton = document.getElementById('core');
+
+const noneAuthCheckbox = document.getElementById('noneAuth');
+const fileRealmCheckbox = document.getElementById('formAuthFileRealm');
+const databaseCheckbox = document.getElementById('formAuthDB');
+const ldapCheckbox = document.getElementById('formAuthLDAP');
+
+coreRadioButton.addEventListener('change', function(event) {
+    if (event.target.checked) {
+        // Disable Form Authentication checkboxes for the Core Profile
+        fileRealmCheckbox.disabled = true;
+        databaseCheckbox.disabled = true;
+        ldapCheckbox.disabled = true;
+
+        fileRealmCheckbox.checked = false;
+        databaseCheckbox.checked = false;
+        ldapCheckbox.checked = false;
+        noneAuthCheckbox.checked = true;
+    }
+});
+
+platformRadioButton.addEventListener('change', toggleFormAuthCheckboxes);
+webRadioButton.addEventListener('change', toggleFormAuthCheckboxes);
+
+// Function to toggle Form Authentication checkboxes for Platform and Web profiles
+function toggleFormAuthCheckboxes(event) {
+    if (platformRadioButton.checked || webRadioButton.checked) {
+        // Enable Form Authentication checkboxes for Platform or Web Profile
+        fileRealmCheckbox.disabled = false;
+        databaseCheckbox.disabled = false;
+        ldapCheckbox.disabled = false;
+    }
+}

--- a/starter-ui/src/main/webapp/assets/main.js
+++ b/starter-ui/src/main/webapp/assets/main.js
@@ -176,10 +176,13 @@ function populatePayaraVersionsDropdown(jakartaEEVersion) {
 
 const jakartaEEVersionSelect = document.getElementById('jakartaEEVersion');
 const javaVersionSelect = document.getElementById('javaVersion');
+const webProfileRadioButton = document.getElementById('web');
+const coreProfileRadioButton = document.getElementById('core');
 
 // Attach an event listener to the jakartaEEVersion select element
 jakartaEEVersionSelect.addEventListener('change', function (event) {
     const selectedValue = event.target.value;
+    const selectedVersion = parseFloat(selectedValue);
 
     // Call the function to populate the Payara version dropdown with the selected Jakarta EE version
     populatePayaraVersionsDropdown(selectedValue);
@@ -198,6 +201,17 @@ jakartaEEVersionSelect.addEventListener('change', function (event) {
     } else {
         addJavaVersionOption('17', 'Java SE 17');
         addJavaVersionOption('11', 'Java SE 11');
+    }
+
+    // Disable the Core Profile radio button for versions below 10
+    if (selectedVersion < 10) {
+        if(coreProfileRadioButton.checked) {
+            webProfileRadioButton.checked = true;
+        }
+        coreProfileRadioButton.disabled = true;
+        coreProfileRadioButton.checked = false;
+    } else {
+        coreProfileRadioButton.disabled = false;
     }
 });
 

--- a/starter-ui/src/main/webapp/assets/main.js
+++ b/starter-ui/src/main/webapp/assets/main.js
@@ -1,3 +1,41 @@
+/*
+ *
+ * Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
 const buildInputs = document.querySelectorAll('input[name="build"]');
 buildInputs.forEach(input => {
     input.addEventListener('click', updateLabelsForBuildSystem);

--- a/starter-ui/src/main/webapp/assets/styles.css
+++ b/starter-ui/src/main/webapp/assets/styles.css
@@ -1,3 +1,41 @@
+/*
+ *
+ * Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
 body {
     background-color: #002c3e;
     font-family: Arial, sans-serif;

--- a/starter-ui/src/main/webapp/index.html
+++ b/starter-ui/src/main/webapp/index.html
@@ -1,4 +1,41 @@
 <!DOCTYPE html>
+<!--
+  Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+ 
+  The contents of this file are subject to the terms of either the GNU
+  General Public License Version 2 only ("GPL") or the Common Development
+  and Distribution License("CDDL") (collectively, the "License").  You
+  may not use this file except in compliance with the License.  You can
+  obtain a copy of the License at
+  https://github.com/payara/Payara/blob/master/LICENSE.txt
+  See the License for the specific
+  language governing permissions and limitations under the License.
+ 
+  When distributing the software, include this License Header Notice in each
+  file and include the License file at glassfish/legal/LICENSE.txt.
+ 
+  GPL Classpath Exception:
+  The Payara Foundation designates this particular file as subject to the "Classpath"
+  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+  file that accompanied this code.
+ 
+  Modifications:
+  If applicable, add the following below the License Header, with the fields
+  enclosed by brackets [] replaced by your own identifying information:
+  "Portions Copyright [year] [name of copyright owner]"
+ 
+  Contributor(s):
+  If you wish your version of this file to be governed by only the CDDL or
+  only the GPL Version 2, indicate your decision by adding "[Contributor]
+  elects to include this software in this distribution under the [CDDL or GPL
+  Version 2] license."  If you don't indicate a single choice of license, a
+  recipient has the option to distribute your version of this file under
+  either the CDDL, the GPL Version 2 or to extend the choice of license to
+  its licensees as provided above.  However, if you add GPL Version 2 code
+  and therefore, elected the GPL Version 2 license, then the option applies
+  only if the new code is made subject to such option by the copyright
+  holder.
+-->
 <html lang="en" class="no-js">
     <head>
         <meta charset="UTF-8">

--- a/starter-ui/src/main/webapp/index.html
+++ b/starter-ui/src/main/webapp/index.html
@@ -319,8 +319,8 @@
                                                 <div class="form-steps__inner">
                                                     <p class="form__row">
                                                         <span class="form__label">Login</span>
-                                                        <input class="form__radbox" type="radio" name="auth" id="none" value="none" checked>
-                                                        <label class="form__radbox-label" for="none">None</label>
+                                                        <input class="form__radbox" type="radio" name="auth" id="noneAuth" value="none" checked>
+                                                        <label class="form__radbox-label" for="noneAuth">None</label>
                                                         <br>
                                                         <input class="form__radbox" type="radio" name="auth" id="formAuthFileRealm" value="formAuthFileRealm">
                                                         <label class="form__radbox-label" for="formAuthFileRealm">Form Authentication - File Realm</label>


### PR DESCRIPTION
The current setup allows the Jakarta EE Core Profile to function across all versions of EE, including those below version 10. However, this profile is not available for EE versions lower than 10, leading to potential system instability and compatibility issues.
![image](https://github.com/payara/ecosystem-starter/assets/15934072/15063e33-90ac-4ac2-b8f1-f06e39724281)

Another improvement done in this PR is to disable the Login feature for the Core profile.
