### PR TITLE
FISH-8087 JDK 21 Support in Payara Starter

### DIFF
--- a/starter-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/starter-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -35,7 +35,7 @@ private void validateInput(String profile, String jakartaEEVersion, String javaV
     }
 
     if (!isValidJavaVersion(javaVersion)) {
-        throwAndDelete("Failed, valid Java SE versions are 8, 11, and 17", outputDirectory);
+        throwAndDelete("Failed, valid Java SE versions are 8, 11, 17, and 21", outputDirectory);
     }
 
     if (!isValidPlatform(platform)) {
@@ -60,7 +60,7 @@ private boolean isValidProfile(String profile) {
 }
 
 private boolean isValidJavaVersion(String version) {
-    return version.equals("8") || version.equals("11") || version.equals("17");
+    return version.equals("8") || version.equals("11") || version.equals("17") || version.equals("21");
 }
 
 private boolean isValidPlatform(String platform) {

--- a/starter-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/starter-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -70,7 +70,7 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
         </requiredProperty>
         <requiredProperty key="javaVersion">
             <defaultValue>17</defaultValue>
-            <validationRegex>^(8|11|17)$</validationRegex>
+            <validationRegex>^(8|11|17|21)$</validationRegex>
         </requiredProperty>
         <requiredProperty key="platform">
             <defaultValue>server</defaultValue>

--- a/starter-archetype/src/main/resources/archetype-resources/Dockerfile
+++ b/starter-archetype/src/main/resources/archetype-resources/Dockerfile
@@ -6,7 +6,13 @@
 #end
 #end
 #if (${platform} == 'server')
-#if (${javaVersion} == '17')
+#if (${javaVersion} == '21')
+#if (${profile} == 'full')
+#set ($baseImage = "payara/server-full:${payaraVersion}-jdk21")
+#else
+#set ($baseImage = "payara/server-web:${payaraVersion}-jdk21")
+#end
+#elseif (${javaVersion} == '17')
 #if (${profile} == 'full')
 #set ($baseImage = "payara/server-full:${payaraVersion}-jdk17")
 #else
@@ -26,7 +32,9 @@
 #end
 #end
 #elseif (${platform} == 'micro')
-#if (${javaVersion} == '17')
+#if (${javaVersion} == '21')
+#set ($baseImage = "payara/micro:${payaraVersion}-jdk21")
+#elseif (${javaVersion} == '17')
 #set ($baseImage = "payara/micro:${payaraVersion}-jdk17")
 #elseif (${javaVersion} == '11')
 #set ($baseImage = "payara/micro:${payaraVersion}-jdk11")

--- a/starter-archetype/src/main/resources/archetype-resources/README.md
+++ b/starter-archetype/src/main/resources/archetype-resources/README.md
@@ -19,7 +19,7 @@ To run the application locally, follow these steps:
 
 1. Open a terminal and navigate to the project's root directory.
 
-2. Make sure you have the appropriate Java version installed. We have tested with Java SE 8, Java SE 11, and Java SE 17.
+2. Make sure you have the appropriate Java version installed. We have tested with Java SE 8, Java SE 11, Java SE 17, and Java SE 21.
 
 3. Execute the following command:
 

--- a/starter-ui/src/main/webapp/assets/main.js
+++ b/starter-ui/src/main/webapp/assets/main.js
@@ -91,7 +91,7 @@ form.addEventListener('submit', function (event) {
     event.preventDefault();
 
     document.getElementById('loadingBar').style.display = 'block';
-    document.getElementById('loadingBar').scrollIntoView({ behavior: 'smooth' });
+    document.getElementById('loadingBar').scrollIntoView({behavior: 'smooth'});
 
     const form = event.target;
     const formData = new FormData(form);
@@ -159,11 +159,18 @@ const jakartaVersions = {
 };
 
 const javaVersions = {
+    "21": "Java SE 21",
     "17": "Java SE 17",
     "11": "Java SE 11",
     "8": "Java SE 8"
 };
 
+
+const payaraVersionSelect = document.getElementById('payaraVersion');
+const jakartaEEVersionSelect = document.getElementById('jakartaEEVersion');
+const javaVersionSelect = document.getElementById('javaVersion');
+const webProfileRadioButton = document.getElementById('web');
+const coreProfileRadioButton = document.getElementById('core');
 
 // Function to populate a select element with options
 function populateSelect(selectId, optionOrder, optionMap) {
@@ -195,55 +202,34 @@ function populatePayaraVersionsDropdown(jakartaEEVersion) {
                 }
             })
             .then(versions => {
-                const payaraVersion = document.getElementById('payaraVersion');
-                payaraVersion.innerHTML = ''; // Clear existing options
+                payaraVersionSelect.innerHTML = ''; // Clear existing options
 
                 // Add an option for each version
                 versions.forEach(version => {
                     const option = document.createElement('option');
                     option.value = version;
                     option.text = version;
-                    payaraVersion.appendChild(option);
+                    payaraVersionSelect.appendChild(option);
                 });
+                listJavaVersionOption();
             })
             .catch(error => {
                 console.error('Error:', error);
             });
 }
 
-
-const jakartaEEVersionSelect = document.getElementById('jakartaEEVersion');
-const javaVersionSelect = document.getElementById('javaVersion');
-const webProfileRadioButton = document.getElementById('web');
-const coreProfileRadioButton = document.getElementById('core');
-
 // Attach an event listener to the jakartaEEVersion select element
 jakartaEEVersionSelect.addEventListener('change', function (event) {
+    
     const selectedValue = event.target.value;
     const selectedVersion = parseFloat(selectedValue);
 
     // Call the function to populate the Payara version dropdown with the selected Jakarta EE version
     populatePayaraVersionsDropdown(selectedValue);
 
-    // Get the "Java Version" options select element
-    const javaVersionOptions = javaVersionSelect.querySelectorAll('option');
-    // Clear existing options
-    javaVersionOptions.forEach(option => {
-        option.remove();
-    });
-
-    // Add options based on the selected Jakarta EE Version
-    if (selectedValue === '8') {
-        addJavaVersionOption('11', 'Java SE 11');
-        addJavaVersionOption('8', 'Java SE 8');
-    } else {
-        addJavaVersionOption('17', 'Java SE 17');
-        addJavaVersionOption('11', 'Java SE 11');
-    }
-
     // Disable the Core Profile radio button for versions below 10
     if (selectedVersion < 10) {
-        if(coreProfileRadioButton.checked) {
+        if (coreProfileRadioButton.checked) {
             webProfileRadioButton.checked = true;
         }
         coreProfileRadioButton.disabled = true;
@@ -252,6 +238,53 @@ jakartaEEVersionSelect.addEventListener('change', function (event) {
         coreProfileRadioButton.disabled = false;
     }
 });
+
+// Attach an event listener to the payaraVersion select element
+payaraVersionSelect.addEventListener('change', function (event) {
+    listJavaVersionOption();
+});
+
+// List Java Version options based on the selected Jakarta EE Version and Payara Version
+function listJavaVersionOption() {
+    const jakartaEEVersion = jakartaEEVersionSelect.value;
+    const payaraVersion = payaraVersionSelect.value;
+
+    // Get the "Java Version" options select element
+    const javaVersionOptions = javaVersionSelect.querySelectorAll('option');
+    // Clear existing options
+    javaVersionOptions.forEach(option => {
+        option.remove();
+    });
+    // Add options based on the selected Jakarta EE Version
+    if (jakartaEEVersion === '8') {
+        addJavaVersionOption('11', 'Java SE 11');
+        addJavaVersionOption('8', 'Java SE 8');
+    } else {
+        if (compareVersion(payaraVersion, '6.2023.11') > 0) {
+            // Payara version is greater than '6.2023.11'
+            addJavaVersionOption('21', 'Java SE 21');
+        }
+        addJavaVersionOption('17', 'Java SE 17');
+        addJavaVersionOption('11', 'Java SE 11');
+    }
+}
+
+// Function to compare two version strings
+function compareVersion(version1, version2) {
+    const v1 = version1.split('.').map(Number);
+    const v2 = version2.split('.').map(Number);
+
+    for (let i = 0; i < Math.max(v1.length, v2.length); i++) {
+        const num1 = v1[i] || 0;
+        const num2 = v2[i] || 0;
+
+        if (num1 !== num2) {
+            return num1 - num2;
+        }
+    }
+
+    return 0;
+}
 
 // Function to add an option to the "Java Version" select element
 function addJavaVersionOption(value, text) {
@@ -305,7 +338,7 @@ const fileRealmCheckbox = document.getElementById('formAuthFileRealm');
 const databaseCheckbox = document.getElementById('formAuthDB');
 const ldapCheckbox = document.getElementById('formAuthLDAP');
 
-coreRadioButton.addEventListener('change', function(event) {
+coreRadioButton.addEventListener('change', function (event) {
     if (event.target.checked) {
         // Disable Form Authentication checkboxes for the Core Profile
         fileRealmCheckbox.disabled = true;


### PR DESCRIPTION
This pull request (PR) addresses the enhancement of Payara Starter by incorporating full compatibility and support for JDK 21. Starting from Payara Version `6.2023.12`, users can take advantage of the latest features and improvements introduced in JDK 21.