### PR TITLE
FISH-8267 Dead Documentation Link in Payara Starter's Default Hello World Project

### DIFF
--- a/starter-archetype/src/main/resources/archetype-resources/src/main/webapp/index.html
+++ b/starter-archetype/src/main/resources/archetype-resources/src/main/webapp/index.html
@@ -63,7 +63,7 @@
             Dive into the world of Jakarta EE with Payara. Our robust application server empowers you to build and deploy scalable, enterprise-ready solutions with ease.
         </p>
         <p>
-            Explore the incredible features of Payara, from seamless clustering to unparalleled support. Get started on your journey with Payara by checking out our <a href="https://www.payara.fish/documentation">documentation</a>.
+            Explore the incredible features of Payara, from seamless clustering to unparalleled support. Get started on your journey with Payara by checking out our <a href="https://docs.payara.fish/">documentation</a>.
         </p>
     </body>
 </html>


### PR DESCRIPTION
There is a dead link in the generated application of Payara Starter's default hello world project. The issue is specifically located on the hello world sample page, where at the bottom, there is a reference to exploring Payara's features through documentation. The link appears to be broken.