### PR TITLE
FISH-8272 Set CDI beans.xml bean-discovery-mode to 'all' for Metrics Annotation Scanning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 /.idea/*
 /*.iml
 /starter-archetype/payara-starter-archetype.iml
+/starter-archetype/src/main/resources/archetype-resources/.gradle
 /starter-ui/payara-starter-ui.iml

--- a/starter-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/beans.xml
+++ b/starter-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/beans.xml
@@ -2,6 +2,6 @@
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
-       bean-discovery-mode="annotated"
+       bean-discovery-mode="all"
        version="4.0">
 </beans>


### PR DESCRIPTION
The current configuration of the Payara Starter application's `beans.xml` file needs to be adjusted to ensure that Metrics annotations are properly scanned from REST endpoints. Currently, only annotated beans are being discovered, leading to Metrics annotations not being recognized.

To resolve this issue, set the `bean-discovery-mode` in the `beans.xml` file to `all`. This change will ensure that all classes, including those without annotations, are scanned for CDI beans, allowing Metrics annotations in REST endpoints to be properly recognized.