### PR TITLE
FISH-8271 Update fallback method signature in Payara Starter

### DIFF
--- a/starter-archetype/src/main/resources/archetype-resources/src/main/java/hello/HelloWorldResource.java
+++ b/starter-archetype/src/main/resources/archetype-resources/src/main/java/hello/HelloWorldResource.java
@@ -43,9 +43,11 @@ public class HelloWorldResource {
                 .build();
     }
 
-    <% if (mpFaultTolerance) { %>public String fallbackMethod() {
-        // Fallback logic when the getData method fails or exceeds retries
-        return "Fallback data";
+    <% if (mpFaultTolerance) { %>public Response fallbackMethod(@QueryParam("name") String name) {
+        // Fallback logic when the hello method fails or exceeds retries
+        return Response
+                .ok("Fallback data")
+                .build();
     }<% } %>
-        
+
 }


### PR DESCRIPTION
The fallback method signature in the Payara Starter application needs to be updated to match the original method's signature. Currently, the fallback method is defined as follows:
```
public String fallbackMethod() {
        // Fallback logic when the getData method fails or exceeds retries
        return "Fallback data";
}
```
However, the original method has a different signature:
```
public Response hello(@QueryParam("name") String name) { ... }
```
To resolve this issue, updated the fallback method signature to match the original method:
```
    public Response fallbackMethod(@QueryParam("name") String name) {
        // Fallback logic when the hello method fails or exceeds retries
        return Response
                .ok("Fallback data")
                .build();
    }
```