### PR TITLE
chore: use IPv4 Stack instead of IPv6 Stack

### DIFF
--- a/starter-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/starter-archetype/src/main/resources/archetype-resources/pom.xml
@@ -203,6 +203,12 @@
 #if (${deployWar} == "true")
                     <deployWar>true</deployWar>
 #end
+                    <!-- use IPv4 stack instead of IPv6 stack-->
+                    <javaCommandLineOptions>
+                        <option>
+                            <value>-Djava.net.preferIPv4Stack=true</value>
+                        </option>
+                    </javaCommandLineOptions>
 #if (${autoBindHttp} == "true")
                     <commandLineOptions>
                         <option>
@@ -239,6 +245,8 @@
 #if ((${platform} == 'server'))
                         <payara.home>${payara.home}</payara.home>
 #else
+                        <!-- use IPv4 stack instead of IPv6 stack -->
+                        <payara.cmdOptions>-Djava.net.preferIPv4Stack=true</payara.cmdOptions>
                         <payara.microJar>${project.build.directory}/payara-micro-${payara.version}.jar</payara.microJar>
 #end
                     </systemPropertyVariables>


### PR DESCRIPTION
Hello, Payara friends!

I didn't see any contribution guide or something like that, but I'd like to contribute with a little improvement to the https://start.payara.fish/ that I think Payara users will benefit from.

I faced problems executing the project generated by the portal without setting the JVM to prefer to use the IPv4 stack by default.

I believe these changes can make the Payara users' life easier!

Congrats to you all on this project!

Cheers,

Max