### PR TITLE
FISH-8660 Add Payara Cloud Maven Plugin support in Payara Starter

### DIFF
--- a/starter-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/starter-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -114,6 +114,10 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
             <defaultValue>false</defaultValue>
             <validationRegex>^(false|true)$</validationRegex>
         </requiredProperty>
+        <requiredProperty key="cloud">
+            <defaultValue>false</defaultValue>
+            <validationRegex>^(false|true)$</validationRegex>
+        </requiredProperty>
         <requiredProperty key="mpConfig">
             <defaultValue>false</defaultValue>
             <validationRegex>^(false|true)$</validationRegex>

--- a/starter-archetype/src/main/resources/archetype-resources/README.md
+++ b/starter-archetype/src/main/resources/archetype-resources/README.md
@@ -49,6 +49,20 @@ To run the application locally, follow these steps:
 4. Once the runtime starts, you can access the project at http://localhost:8080/
 #end
 
+#if (${cloud} == 'true')
+#[[##]]# Deploying to Payara Cloud
+To deploy the application to Payara Cloud follow these steps:
+
+#if (${build} == 'maven')
+Open a terminal and navigate to the project's root directory.
+Execute the following Maven command to build the application and deploy to the Payara Cloud:
+
+```
+./mvn clean package payara-cloud:dev
+```
+#end
+#end
+
 #if (${docker} == 'true')
 #[[##]]# Building a Docker Image
 To build a Docker image for this application follow these steps:

--- a/starter-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/starter-archetype/src/main/resources/archetype-resources/pom.xml
@@ -229,6 +229,14 @@
                     </configuration>
             </plugin>
 #end
+#if (${cloud} == "true")
+            <!-- Execute 'mvn clean package payara-cloud:dev' to run the application in Payara Cloud. -->
+            <plugin>
+                <groupId>fish.payara.maven.plugins</groupId>
+                <artifactId>payara-cloud-maven-plugin</artifactId>
+                <version>1.0-Alpha1</version>
+            </plugin>
+#end
 #if (${includeTests} == "true")
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/starter-ui/nb-configuration.xml
+++ b/starter-ui/nb-configuration.xml
@@ -14,5 +14,6 @@ That way multiple projects can share the same settings (useful for formatting ru
 Any value defined here will override the pom.xml file value but is only applicable to the current project.
 -->
         <org-netbeans-modules-maven-j2ee.netbeans_2e_hint_2e_deploy_2e_server>pfv5ee8</org-netbeans-modules-maven-j2ee.netbeans_2e_hint_2e_deploy_2e_server>
+        <org-netbeans-modules-maven-jaxws.rest_2e_config_2e_type>ide</org-netbeans-modules-maven-jaxws.rest_2e_config_2e_type>
     </properties>
 </project-shared-configuration>

--- a/starter-ui/src/main/java/fish/payara/starter/resources/ApplicationConfiguration.java
+++ b/starter-ui/src/main/java/fish/payara/starter/resources/ApplicationConfiguration.java
@@ -59,6 +59,7 @@ public class ApplicationConfiguration {
     public static final String PLATFORM = "platform";
     public static final String INCLUDE_TESTS = "includeTests";
     public static final String DOCKER = "docker";
+    public static final String PAYARA_CLOUD = "cloud";
     public static final String MP_CONFIG = "mpConfig";
     public static final String MP_OPEN_API = "mpOpenAPI";
     public static final String MP_FAULT_TOLERANCE = "mpFaultTolerance";
@@ -109,6 +110,9 @@ public class ApplicationConfiguration {
 
     @JsonbProperty(DOCKER)
     private boolean docker = false;
+
+    @JsonbProperty(PAYARA_CLOUD)
+    private boolean cloud = false;
 
     @JsonbProperty(MP_CONFIG)
     private boolean mpConfig = false;
@@ -325,6 +329,14 @@ public class ApplicationConfiguration {
 
     public void setDocker(boolean docker) {
         this.docker = docker;
+    }
+
+    public boolean isCloud() {
+        return cloud;
+    }
+
+    public void setCloud(boolean cloud) {
+        this.cloud = cloud;
     }
 
     public boolean isMpConfig() {

--- a/starter-ui/src/main/java/fish/payara/starter/resources/ApplicationGeneratorResource.java
+++ b/starter-ui/src/main/java/fish/payara/starter/resources/ApplicationGeneratorResource.java
@@ -52,6 +52,7 @@ import static fish.payara.starter.resources.ApplicationConfiguration.MP_FAULT_TO
 import static fish.payara.starter.resources.ApplicationConfiguration.MP_METRICS;
 import static fish.payara.starter.resources.ApplicationConfiguration.MP_OPEN_API;
 import static fish.payara.starter.resources.ApplicationConfiguration.PACKAGE;
+import static fish.payara.starter.resources.ApplicationConfiguration.PAYARA_CLOUD;
 import static fish.payara.starter.resources.ApplicationConfiguration.PAYARA_VERSION;
 import static fish.payara.starter.resources.ApplicationConfiguration.PLATFORM;
 import static fish.payara.starter.resources.ApplicationConfiguration.PROFILE;
@@ -146,6 +147,7 @@ public class ApplicationGeneratorResource {
         properties.put(INCLUDE_TESTS, appProperties.isIncludeTests());
         properties.put(ADD_PAYARA_API, appProperties.isAddPayaraApi());
         properties.put(DOCKER, appProperties.isDocker());
+        properties.put(PAYARA_CLOUD, appProperties.isCloud());
         properties.put(MP_CONFIG, appProperties.isMpConfig());
         properties.put(MP_OPEN_API, appProperties.isMpOpenAPI());
         properties.put(MP_FAULT_TOLERANCE, appProperties.isMpFaultTolerance());

--- a/starter-ui/src/main/webapp/index.html
+++ b/starter-ui/src/main/webapp/index.html
@@ -338,6 +338,8 @@
                                                     <p class="form__row">
                                                         <input class="form__radbox" type="checkbox" id="docker" name="docker" value="false">
                                                         <label class="form__radbox-label" for="docker">Docker</label>
+                                                        <input class="form__radbox" type="checkbox" id="cloud" name="cloud" value="false">
+                                                        <label class="form__radbox-label" for="cloud">Payara Cloud</label>
                                                     </p>
                                                     <p class="form__row form-steps__controls">
                                                         <a class="button button--ghost form__step__button-back">

--- a/starter-ui/src/main/webapp/index.html
+++ b/starter-ui/src/main/webapp/index.html
@@ -335,12 +335,6 @@
                                                         <label class="form__label" for="payaraVersion">Payara Platform version:</label>
                                                         <select class="form__select" name="payaraVersion" id="payaraVersion"></select>
                                                     </p>
-                                                    <p class="form__row">
-                                                        <input class="form__radbox" type="checkbox" id="docker" name="docker" value="false">
-                                                        <label class="form__radbox-label" for="docker">Docker</label>
-                                                        <input class="form__radbox" type="checkbox" id="cloud" name="cloud" value="false">
-                                                        <label class="form__radbox-label" for="cloud">Payara Cloud</label>
-                                                    </p>
                                                     <p class="form__row form-steps__controls">
                                                         <a class="button button--ghost form__step__button-back">
                                                             <svg class="icon icon--90deg" width="1em" height="1em" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
@@ -351,6 +345,44 @@
                                                         <a class="button button--ghost form__step__button">
                                                             <svg class="icon icon--270deg" width="1em" height="1em" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
                                                                 <use href="ui/images/icons.svg#icon-arrow"></use>
+                                                            </svg>
+                                                            <span class="button__text">Next<span class="visually-hidden">: Deployment Options</span></span>
+                                                        </a>
+                                                    </p>
+                                                </div>
+                                            </div>
+                                        </fieldset>
+                                        
+                                        <fieldset class="form-steps__step">
+                                            <legend class="visually-hidden form-steps__title">Deployment Options</legend>
+                                            <div class="legend h3 form-steps__title" aria-hidden="true">Deployment Options</div>
+                                            <div class="form-steps__icon">
+                                                <svg class="icon" width="1em" height="1em" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+                                                    <use href="ui/images/icons.svg#icon-tick" class="icon--tick"></use>
+                                                    <use href="ui/images/icons.svg#icon-dot" class="icon--dot"></use>
+                                                    <use href="ui/images/icons.svg#icon-dot_outline" class="icon--dot-outline"></use>
+                                                </svg>
+                                            </div>
+                                            <div class="form-steps__fields">
+                                                <div class="form-steps__inner">
+                                                    <p class="form__row">
+                                                        <input class="form__radbox" type="checkbox" id="docker" name="docker" value="false">
+                                                        <label class="form__radbox-label" for="docker">Docker</label>
+                                                    </p>
+                                                    <p class="form__row">
+                                                        <input class="form__radbox" type="checkbox" id="cloud" name="cloud" value="false">
+                                                        <label class="form__radbox-label" for="cloud">Payara Cloud</label>
+                                                    </p>
+                                                    <p class="form__row form-steps__controls">
+                                                        <a class="button button--ghost form__step__button-back">
+                                                            <svg class="icon icon--90deg" width="1em" height="1em" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+                                                            <use href="ui/images/icons.svg#icon-arrow"></use>
+                                                            </svg>
+                                                            <span class="button__text">Previous<span class="visually-hidden">: Payara Platform</span></span>
+                                                        </a>
+                                                        <a class="button button--ghost form__step__button">
+                                                            <svg class="icon icon--270deg" width="1em" height="1em" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+                                                            <use href="ui/images/icons.svg#icon-arrow"></use>
                                                             </svg>
                                                             <span class="button__text">Next<span class="visually-hidden">: Advanced Configuration</span></span>
                                                         </a>


### PR DESCRIPTION
![image](https://github.com/payara/ecosystem-starter/assets/15934072/9744df15-bd3f-43bd-a21a-ee0af35371df)

The above setting must add the following snippet to the pom.xml

```
            <!-- Execute 'mvn clean package payara-cloud:dev' to run the application in Payara Cloud. -->
            <plugin>
                <groupId>fish.payara.maven.plugins</groupId>
                <artifactId>payara-cloud-maven-plugin</artifactId>
                <version>1.0-Alpha1</version>
            </plugin>
 ```