### PR TITLE
Add a new line character for build.gradle template

### DIFF
--- a/starter-archetype/src/main/resources/archetype-resources/build.gradle
+++ b/starter-archetype/src/main/resources/archetype-resources/build.gradle
@@ -56,7 +56,8 @@ targetCompatibility = JavaVersion.VERSION_${javaVersion}
 #if (${platform} == 'micro')
 payaraMicro {
     payaraVersion = '${payaraVersion}'
-    #if (${deployWar} == "true")deployWar = true #end
+    #if (${deployWar} == "true")deployWar = true
+    #end
     useUberJar = false
     daemon = false
     commandLineOptions = [port: 8080]


### PR DESCRIPTION
I am developing in a Windows environment.
In the Gradle project generated by Payara Starter, there is always a lack of a newline character after `deployWar = true` in the build.gradle file.
As a result, it cannot be built. 

<img width="596" alt="shot_240703_231655" src="https://github.com/payara/ecosystem-starter/assets/13513812/82baab6a-9ed1-4c10-bd4f-57d96109ffb1">

I have added a newline character after `deployWar = true`.