### PR TITLE
FISH-9958 fix payara starter archetype

### DIFF
--- a/starter-archetype/pom.xml
+++ b/starter-archetype/pom.xml
@@ -51,7 +51,29 @@
         <version>1.0-beta9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <version>4.0.23</version>
+            <type>pom</type>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy-templates</artifactId>
+            <version>4.0.23</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-archetype-plugin</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+    </dependencies>
+
     <build>
+
         <extensions>
             <extension>
                 <groupId>org.apache.maven.archetype</groupId>

--- a/starter-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/starter-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -136,6 +136,25 @@ private generateSource(build, _package, platform, jakartaEEVersion,
         FileUtils.forceDelete(new File(outputDirectory.path + "/src/main/webapp/secured"))
         FileUtils.forceDelete(new File(outputDirectory.path + "/src/main/webapp/admin"))
     }
+
+    //Temporary bypass for the groovy scripts not working as it is not deleting <% if (...){} %> templating code
+    if (!mpOpenAPI.equalsIgnoreCase("true") && !mpConfig.equalsIgnoreCase("true")) {
+        // Delete the HelloWorldResource.java file which contains template language
+        FileUtils.forceDelete(new File(outputDirectory, "src/main/java/" + packagePath + "/hello/HelloWorldResource.java"))
+
+        // Rename SimpleHelloWorldResource.java to HelloWorldResource.java
+        File defaultFile = new File(outputDirectory, "src/main/java/" + packagePath + "/hello/SimpleHelloWorldResource.java")
+        File renamedFile = new File(outputDirectory, "src/main/java/" + packagePath + "/hello/HelloWorldResource.java")
+
+        if (defaultFile.exists()) {
+            boolean renamed = defaultFile.renameTo(renamedFile)
+            if (!renamed) {
+                throw new RuntimeException("Failed to rename SimpleHelloWorldResource.java to HelloWorldResource.java")
+            }
+        } else {
+            throw new RuntimeException("SimpleHelloWorldResource.java does not exist.")
+        }
+    }
 }
 
 static void bindEEPackage(String jakartaEEVersion,  String mpConfig, String mpOpenAPI, String mpFaultTolerance, String mpMetrics, String auth, File outputDirectory) throws IOException {

--- a/starter-archetype/src/main/resources/archetype-resources/src/main/java/hello/SimpleHelloWorldResource.java
+++ b/starter-archetype/src/main/resources/archetype-resources/src/main/java/hello/SimpleHelloWorldResource.java
@@ -1,0 +1,24 @@
+package ${package}.hello;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Response;
+
+@Path("hello")
+public class HelloWorldResource {
+
+
+    @GET
+    public Response hello(@QueryParam("name") String name) {
+        if ((name == null) || name.trim().isEmpty()) {
+            name = "world";
+        }
+        return Response
+                .ok(name)
+                .build();
+    }
+
+
+
+}


### PR DESCRIPTION
I have fixed the issue of the `mvn archetype:generate` command not working. I have used java tech instead of groovy to change the functionality of `archetype-post-generate.groovy` as the groovy scripts are not working right now.

As a result of the groovy scripts not working, this means that the template language in `HelloWorldResource.java` will not work as even if mpOpenAPI is false, it will still display the `<% if(...){} %>`. The temporary solution I could come up with is if both the `mpOpenAPI` and `mpConfig` are false, it will delete the `HelloWorldResource` and replace it with the `SimpleHelloWorldResource` which is just a plain resource.

This is just a temporary solution as I tried removing the template code programatically but was unsuccessful.