### PR TITLE
FISH-9719  Implement Security filters to Suspend Usage When OpenAI API Max Count is Reached

### DIFF
--- a/starter-ui/src/main/java/fish/payara/starter/ERDiagramResource.java
+++ b/starter-ui/src/main/java/fish/payara/starter/ERDiagramResource.java
@@ -48,6 +48,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.core.MediaType;
 
 @Path("/er-diagram")
+@RateLimited
 public class ERDiagramResource {
 
     @Inject

--- a/starter-ui/src/main/java/fish/payara/starter/IpRateLimitFilter.java
+++ b/starter-ui/src/main/java/fish/payara/starter/IpRateLimitFilter.java
@@ -67,7 +67,7 @@ import java.util.concurrent.TimeUnit;
  * Author: Gaurav Gupta
  */
 @Provider
-@fish.payara.starter.RateLimited
+@RateLimited
 @Priority(Priorities.AUTHORIZATION)
 public class IpRateLimitFilter implements ContainerRequestFilter {
 

--- a/starter-ui/src/main/java/fish/payara/starter/IpRateLimitFilter.java
+++ b/starter-ui/src/main/java/fish/payara/starter/IpRateLimitFilter.java
@@ -117,11 +117,9 @@ public class IpRateLimitFilter implements ContainerRequestFilter {
     private boolean isIpBlocked(String clientIp) {
         Deque<Long> timestamps = ipAccessLogs.getOrDefault(clientIp, new ConcurrentLinkedDeque<>());
         long now = Instant.now().toEpochMilli();
-        System.out.println("clientIp1 " + clientIp + " tss:" + timestamps.size());
         while (!timestamps.isEmpty() && now - timestamps.peekFirst() > timeWindow) {
             timestamps.pollFirst();
         }
-        System.out.println("clientIp2 " + clientIp + " tss:" + timestamps.size() + " - " + limit);
         return timestamps.size() >= limit;
     }
 

--- a/starter-ui/src/main/java/fish/payara/starter/IpRateLimitFilter.java
+++ b/starter-ui/src/main/java/fish/payara/starter/IpRateLimitFilter.java
@@ -1,0 +1,163 @@
+/*
+ *
+ * Copyright (c) 2024 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.starter;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.Priority;
+import jakarta.annotation.Resource;
+import jakarta.enterprise.concurrent.ManagedScheduledExecutorService;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * JAX-RS Filter for rate limiting based on IP address. Blocks requests if the
+ * client exceeds the configured API call limit within the specified time
+ * window.
+ *
+ * Author: Gaurav Gupta
+ */
+@Provider
+@fish.payara.starter.RateLimited
+@Priority(Priorities.AUTHORIZATION)
+public class IpRateLimitFilter implements ContainerRequestFilter {
+
+    private static final int SC_TOO_MANY_REQUESTS = 429;
+    private final int limit;
+    private final long timeWindow;
+    private final ConcurrentHashMap<String, Deque<Long>> ipAccessLogs = new ConcurrentHashMap<>();
+
+    @Resource
+    private ManagedScheduledExecutorService scheduler;
+
+    public IpRateLimitFilter() {
+        Config config = ConfigProvider.getConfig();
+        this.limit = config.getOptionalValue("rate.limit", Integer.class).orElse(100); // Default to 100
+        this.timeWindow = config.getOptionalValue("rate.time.window", Long.class).orElse(3600_000L); // Default to 1 hour
+    }
+
+    /**
+     * Start the cleanup task periodically when the application is deployed.
+     */
+    @PostConstruct
+    public void startCleanupTask() {
+        scheduler.scheduleAtFixedRate(this::cleanOldEntries, 0, 1, TimeUnit.HOURS);
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        String clientIp = getClientIp(requestContext);
+
+        if (clientIp == null || clientIp.isEmpty()) {
+            requestContext.abortWith(Response.status(Response.Status.BAD_REQUEST)
+                    .entity("Unable to determine client IP")
+                    .build());
+            return;
+        }
+
+        if (isIpBlocked(clientIp)) {
+            requestContext.abortWith(Response.status(SC_TOO_MANY_REQUESTS)
+                    .entity("Rate limit exceeded")
+                    .build());
+            return;
+        }
+
+        logApiCall(clientIp);
+    }
+
+    private boolean isIpBlocked(String clientIp) {
+        Deque<Long> timestamps = ipAccessLogs.getOrDefault(clientIp, new ConcurrentLinkedDeque<>());
+        long now = Instant.now().toEpochMilli();
+        System.out.println("clientIp1 " + clientIp + " tss:" + timestamps.size());
+        while (!timestamps.isEmpty() && now - timestamps.peekFirst() > timeWindow) {
+            timestamps.pollFirst();
+        }
+        System.out.println("clientIp2 " + clientIp + " tss:" + timestamps.size() + " - " + limit);
+        return timestamps.size() >= limit;
+    }
+
+    private void logApiCall(String clientIp) {
+        long now = Instant.now().toEpochMilli();
+        ipAccessLogs.computeIfAbsent(clientIp, key -> new ConcurrentLinkedDeque<>()).addLast(now);
+    }
+
+    private String getClientIp(ContainerRequestContext requestContext) {
+        String ip = requestContext.getHeaderString("X-Forwarded-For");
+        if (ip == null || ip.isEmpty()) {
+            ip = requestContext.getUriInfo().getRequestUri().getHost();
+        }
+        return ip;
+    }
+
+    /**
+     * Scheduled cleanup to remove old IP access logs entries periodically.
+     */
+    private void cleanOldEntries() {
+        long now = Instant.now().toEpochMilli();
+
+        Iterator<Map.Entry<String, Deque<Long>>> iterator = ipAccessLogs.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<String, Deque<Long>> entry = iterator.next();
+            Deque<Long> timestamps = entry.getValue();
+
+            while (!timestamps.isEmpty() && now - timestamps.peekFirst() > timeWindow) {
+                timestamps.pollFirst();
+            }
+
+            // Remove the entry if it has no recent timestamps left
+            if (timestamps.isEmpty()) {
+                iterator.remove();
+            }
+        }
+    }
+
+}

--- a/starter-ui/src/main/java/fish/payara/starter/RateLimited.java
+++ b/starter-ui/src/main/java/fish/payara/starter/RateLimited.java
@@ -1,0 +1,55 @@
+/*
+ *
+ * Copyright (c) 2024 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.starter;
+
+import jakarta.ws.rs.NameBinding;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ *
+ * @author Gaurav Gupta
+ */
+@NameBinding
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RateLimited {
+}

--- a/starter-ui/src/main/java/fish/payara/starter/resources/ApplicationGenerator.java
+++ b/starter-ui/src/main/java/fish/payara/starter/resources/ApplicationGenerator.java
@@ -113,7 +113,6 @@ public class ApplicationGenerator {
     private LangChainChatService langChainChatService;
 
     public Future<File> generate(ApplicationConfiguration appProperties) {
-        System.out.println("executorService " + executorService);
         return executorService.submit(() -> {
             File applicationDir = null;
             try {
@@ -158,15 +157,13 @@ public class ApplicationGenerator {
                                 appProperties.isGenerateRest(),
                                 appProperties.isGenerateWeb());
                     } catch (Exception e) {
-                        e.printStackTrace();
-                        LOGGER.log(Level.SEVERE, "Error generating application: {0}", e.getMessage());
+                        LOGGER.log(Level.SEVERE, "Error generating application: " + e.getMessage(), e);
                     }
                     Path diagramPath = Paths.get(applicationDir.getAbsolutePath(), appProperties.getErDiagramName().trim().replaceAll("\\s+", "_") + ".mmd");
                     Files.write(diagramPath, appProperties.getErDiagram().getBytes());
                 }
                 return zipDirectory(applicationDir, workingDirectory);
             } catch (Exception ie) {
-                ie.printStackTrace();
                 throw new RuntimeException("Failed to generate application.", ie);
             } finally {
                 if (applicationDir != null) {

--- a/starter-ui/src/main/resources/META-INF/microprofile-config.properties
+++ b/starter-ui/src/main/resources/META-INF/microprofile-config.properties
@@ -3,4 +3,5 @@ gpt.model=gpt-4o-mini
 gpt.image.mode=dall-e-3
 model.temperature=0.7
 cache.enabled=false
-
+rate.limit=60
+rate.time.window=360000

--- a/starter-ui/src/main/webapp/index.html
+++ b/starter-ui/src/main/webapp/index.html
@@ -871,7 +871,16 @@
                     hideAILoadingBar();
 
                     if (!response.ok) {
-                        throw new Error('Network response was not ok');
+                        if (response.status === 429) {
+                            alert(
+                                "Too many requests have been made in a short period.\n\n" +
+                                "To ensure optimal performance, we limit the number of requests per hour. " +
+                                "Please wait a few moments before trying again. Thank you for your understanding!"
+                            );
+                            throw new Error('Generative AI access is temporarily disabled. Please try again later.');
+                        } else {
+                            throw new Error('Network response was not ok');
+                        }
                     }
 
                     var content = await response.text();

--- a/starter-ui/src/main/webapp/index.html
+++ b/starter-ui/src/main/webapp/index.html
@@ -871,16 +871,7 @@
                     hideAILoadingBar();
 
                     if (!response.ok) {
-                        if (response.status === 429) {
-                            alert(
-                                "Too many requests have been made in a short period.\n\n" +
-                                "To ensure optimal performance, we limit the number of requests per hour. " +
-                                "Please wait a few moments before trying again. Thank you for your understanding!"
-                            );
-                            throw new Error('Generative AI access is temporarily disabled. Please try again later.');
-                        } else {
-                            throw new Error('Network response was not ok');
-                        }
+                        checkLimitExhaust(response);
                     }
 
                     var content = await response.text();
@@ -916,7 +907,7 @@
                     hideAILoadingBar();
 
                     if (!response.ok) {
-                        throw new Error('Network response was not ok');
+                        checkLimitExhaust(response);
                     }
 
                     var content = await response.text();
@@ -954,7 +945,7 @@
                     hideAILoadingBar();
 
                     if (!response.ok) {
-                        throw new Error('Network response was not ok');
+                        checkLimitExhaust(response);
                     }
 
                     var content = await response.text();
@@ -1096,7 +1087,7 @@
                             .then(response => {
                                 hideAILoadingBar();
                                 if (!response.ok) {
-                                    throw new Error('Network response was not ok');
+                                    checkLimitExhaust(response);
                                 }
                                 return response.text();
                             })
@@ -1260,6 +1251,20 @@
                 document.getElementById('loadingBarAI').style.display = 'none';
                 document.getElementById('headerAI').innerHTML = 'Live Preview';
             }
+            
+            function checkLimitExhaust(response) {
+                if (response.status === 429) {
+                    alert(
+                        "Too many requests have been made in a short period.\n\n" +
+                        "To ensure optimal performance, we limit the number of requests per hour. " +
+                        "Please wait a few moments before trying again. Thank you for your understanding!"
+                    );
+                    throw new Error('Generative AI access is temporarily disabled. Please try again later.');
+                } else {
+                    throw new Error('Network response was not ok');
+                }
+            }
+            
         </script>
 
 		<!-- Start of HubSpot Embed Code -->


### PR DESCRIPTION
# Add IP Rate Limiting with Scheduled Cleanup

## Description
- Introduced IP rate limiting for specific REST endpoints using JAX-RS filters.
- Configurable via MicroProfile Config (`rate.limit` (**60**), `rate.time.window` (**1 Hour**)).
- Utilized `ManagedScheduledExecutorService` for periodic cleanup of stale log entries.

## Key Changes
1. Added `IpRateLimitFilter` to restrict Generative AI requests per IP.
2. Implemented scheduled cleanup to optimize memory usage.

## How It Works
- Tracks API calls per IP in a `ConcurrentHashMap`.
- Blocks requests exceeding the limit within the configured time window.
- Periodic cleanup task removes outdated entries.


