### PR TITLE
FISH-10903 test compile generated app

### DIFF
--- a/starter-ui/pom.xml
+++ b/starter-ui/pom.xml
@@ -310,19 +310,13 @@
                                             <![CDATA[
                                             Get-ChildItem -Path ./target/test-app-gradle -Directory | ForEach-Object {
                                                 Push-Location $_.FullName;
-                                                try {
-                                                    & .\gradlew.bat -b build.gradle build;
-                                                    if ($LASTEXITCODE -ne 0) {
-                                                        echo "Gradle build failed in $($_.FullName)"
-                                                    }
-                                                } catch {
-                                                    Write-Error "Error: $_";
-                                                    Exit 1;
-                                                } finally {
-                                                    Pop-Location;
+                                                & .\gradlew.bat -b build.gradle build --no-daemon;
+                                                Pop-Location;
+                                                if ($LASTEXITCODE -ne 0) {
+                                                    Exit $LASTEXITCODE;
                                                 }
                                             }
-                                            Exit $LASTEXITCODE
+                                            Exit 0;
                                             ]]>
                                         </argument>
                                     </arguments>

--- a/starter-ui/pom.xml
+++ b/starter-ui/pom.xml
@@ -131,6 +131,12 @@
             <version>5.12.1</version>
         </dependency>
     </dependencies>
+    
+    <properties>
+        <os.shell>/bin/sh</os.shell>
+        <os.script.extension></os.script.extension>
+    </properties>
+    
     <build>
         <extensions>
             <extension>
@@ -227,6 +233,11 @@
     <profiles>
         <profile>
             <id>e2e</id>
+            <activation>
+                <property>
+                    <name>e2e</name>
+                </property>
+            </activation>
             <!-- to run e2e tests, make sure to have payara starter running
                 for example, use `mvn clean install payara-micro:starter -DcontextRoot="payara-starter" -DdeployWar=true -f ./starter-ui`-->
             <build>
@@ -242,6 +253,152 @@
                                 <goals>
                                     <goal>integration-test</goal>
                                     <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+                <property>
+                    <name>e2e</name>
+                </property>
+            </activation>
+            <properties>
+                <os.shell>powershell</os.shell>
+                <os.script.extension>.bat</os.script.extension>
+            </properties>
+            <build>
+                <plugins> 
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.5.0</version>
+                        <executions>
+                            <execution>
+                                <id>compile-generated-app-maven</id>
+                                <phase>post-integration-test</phase>
+                                <configuration>
+                                    <executable>${os.shell}</executable>
+                                    <arguments>
+                                        <argument>
+                                            <![CDATA[
+                                        Get-ChildItem -Path ./target/test-app-maven -Directory | ForEach-Object { Push-Location $_.FullName; & mvn compile -f pom.xml; Pop-Location }
+                                            ]]>
+                                        </argument>
+                                    </arguments>
+                                </configuration>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>compile-generated-app-gradle</id>
+                                <phase>post-integration-test</phase>
+                                <configuration>
+                                    <executable>${os.shell}</executable>
+                                    <arguments>
+                                        <argument>-NoProfile</argument>
+                                        <argument>-Command</argument>
+                                        <argument>
+                                            <![CDATA[
+                                            Get-ChildItem -Path ./target/test-app-gradle -Directory | ForEach-Object {
+                                                Push-Location $_.FullName;
+                                                try {
+                                                    & .\gradlew.bat -b build.gradle build;
+                                                    if ($LASTEXITCODE -ne 0) {
+                                                        echo "Gradle build failed in $($_.FullName)"
+                                                    }
+                                                } catch {
+                                                    Write-Error "Error: $_";
+                                                    Exit 1;
+                                                } finally {
+                                                    Pop-Location;
+                                                }
+                                            }
+                                            Exit $LASTEXITCODE
+                                            ]]>
+                                        </argument>
+                                    </arguments>
+                                </configuration>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>unix</id>
+            <activation>
+                <os>
+                    <family>unix</family>
+                </os>
+                <property>
+                    <name>e2e</name>
+                </property>
+                <activeByDefault/>
+            </activation>
+            <properties>
+                <os.shell>/bin/sh</os.shell>
+                <os.script.extension></os.script.extension>                
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.5.0</version>
+                        <executions>
+                            <execution>
+                                <id>compile-generated-app-maven</id>
+                                <phase>post-integration-test</phase>
+                                <configuration>
+                                    <executable>${os.shell}</executable>
+                                    <arguments>
+                                        <argument>
+                                            <![CDATA[
+                                            for dir in ./target/test-app-maven/*; do 
+                                                if [ -d "$dir" ]; then 
+                                                    (cd "$dir" && mvn compile); 
+                                                fi; 
+                                            done
+                                            ]]>
+                                        </argument>
+                                    </arguments>
+                                </configuration>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>compile-generated-app-gradle</id>
+                                <phase>post-integration-test</phase>
+                                <configuration>
+                                    <executable>${os.shell}</executable>
+                                    <arguments>
+                                        <argument>-c</argument>
+                                        <argument>
+                                            <![CDATA[
+                                            for dir in ./target/test-app-gradle/*; do 
+                                                if [ -d "$dir" ]; then 
+                                                    (cd "$dir" && ./gradlew -b build.gradle build); 
+                                                fi; 
+                                            done
+                                            ]]>
+                                        </argument>
+                                    </arguments>
+                                </configuration>
+                                <goals>
+                                    <goal>exec</goal>
                                 </goals>
                             </execution>
                         </executions>

--- a/starter-ui/pom.xml
+++ b/starter-ui/pom.xml
@@ -134,7 +134,6 @@
     
     <properties>
         <os.shell>/bin/sh</os.shell>
-        <os.script.extension></os.script.extension>
     </properties>
     
     <build>
@@ -239,7 +238,7 @@
                 </property>
             </activation>
             <!-- to run e2e tests, make sure to have payara starter running
-                for example, use `mvn clean install payara-micro:starter -DcontextRoot="payara-starter" -DdeployWar=true -f ./starter-ui`-->
+            for example, use `mvn clean install payara-micro:start -DcontextRoot="payara-starter" -DdeployWar=true -f ./starter-ui`-->
             <build>
                 <plugins>
                     <plugin>
@@ -272,7 +271,6 @@
             </activation>
             <properties>
                 <os.shell>powershell</os.shell>
-                <os.script.extension>.bat</os.script.extension>
             </properties>
             <build>
                 <plugins> 
@@ -342,8 +340,7 @@
                 <activeByDefault/>
             </activation>
             <properties>
-                <os.shell>/bin/bash</os.shell>
-                <os.script.extension></os.script.extension>                
+                <os.shell>/bin/bash</os.shell>               
             </properties>
             <build>
                 <plugins>

--- a/starter-ui/pom.xml
+++ b/starter-ui/pom.xml
@@ -342,7 +342,7 @@
                 <activeByDefault/>
             </activation>
             <properties>
-                <os.shell>/bin/sh</os.shell>
+                <os.shell>/bin/bash</os.shell>
                 <os.script.extension></os.script.extension>                
             </properties>
             <build>
@@ -358,6 +358,7 @@
                                 <configuration>
                                     <executable>${os.shell}</executable>
                                     <arguments>
+                                        <argument>-c</argument>
                                         <argument>
                                             <![CDATA[
                                             for dir in ./target/test-app-maven/*; do 
@@ -384,7 +385,8 @@
                                             <![CDATA[
                                             for dir in ./target/test-app-gradle/*; do 
                                                 if [ -d "$dir" ]; then 
-                                                    (cd "$dir" && ./gradlew -b build.gradle build); 
+                                                    chmod +x "$dir/gradlew";
+                                                    (cd "$dir" && ./gradlew -b build.gradle build) || exit 1; 
                                                 fi; 
                                             done
                                             ]]>

--- a/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/GenerationAppIT.java
+++ b/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/GenerationAppIT.java
@@ -42,8 +42,12 @@ import com.microsoft.playwright.*;
 import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
 import com.microsoft.playwright.junit.UsePlaywright;
 import fish.payara.starter.test.e2e.pages.*;
+import fish.payara.starter.test.e2e.utils.FileManagement;
+import java.io.File;
+import java.io.IOException;
 import java.nio.file.Paths;
 import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @UsePlaywright
 public class GenerationAppIT {
@@ -81,35 +85,46 @@ public class GenerationAppIT {
     }
     
     @Test
-    void shouldGenerateSimpleApp() throws InterruptedException {
+    void shouldGenerateSimpleApp() throws InterruptedException, IOException {
         assertThat(page).hasTitle("Generate Payara Application");
         starterPage.setProjectDescription("Gradle", "fish.payara.playwright.test", "PlaywrightTest", "1.0");
         starterPage.setJakartaEE("Jakarta EE 9.1", "9.1", "Web Profile");
         starterPage.closeGuidePopup();
         starterPage.setPayaraPlatform("Payara Micro", "6.2025.1", "6.2025.1");
-        starterPage.setProjectConfiguration("fish.payara.e2e", true, "Java SE 17", "17");
+        starterPage.setProjectConfiguration("fish.payara.e2e", false, "Java SE 17", "17");
         starterPage.setMicroProfile("Full MP");
         starterPage.setDeployment(true, false);
-        starterPage.setERDiagram("", true, "domain.test", false, "service.test", false, "resource", true);
+        starterPage.setERDiagram("", true, "domain", false, "service", false, "resource", true);
         starterPage.setSecurity("Form Authentication - File Realm");
-        starterPage.generate(page, Paths.get("./target", "PlaywrightTest.zip"));
+        starterPage.generate(page, Paths.get("./target/test-app-gradle", "PlaywrightTest.zip"));
+
+        FileManagement.unzip("./target/test-app-gradle/PlaywrightTest.zip", "./target/test-app-gradle/PlaywrightTest");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-gradle/PlaywrightTest/build.gradle")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-gradle/PlaywrightTest/build.gradle"),
+                "sourceCompatibility = JavaVersion.VERSION_17"));
+
     }
 
     @Test
-    void shouldModifyAppWithERDiagram() throws InterruptedException {
+    void shouldModifyAppWithERDiagram() throws InterruptedException, IOException {
         starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "InventorySystemTest", "1.0-SNAPSHOT");
-        starterPage.setJakartaEE("Jakarta EE 10", "10", "Web Profile");
+        starterPage.setJakartaEE("Jakarta EE 8", "8", "Web Profile");
         starterPage.closeGuidePopup();
-        starterPage.setPayaraPlatform("Payara Server", "6.2025.4", "6.2025.4");
-        starterPage.setProjectConfiguration("fish.payara.e2e", false, "Java SE 21", "21");
+        starterPage.setPayaraPlatform("Payara Server", "5.2022.5", "5.2022.5");
+        starterPage.setProjectConfiguration("fish.payara.e2e", true, "Java SE 11", "11");
         starterPage.setMicroProfile("MicroProfile Metrics");
         starterPage.setDeployment(false, false);
-        starterPage.setERDiagram("Inventory System", true, "domain.test", false, "service.test", false, "resource", true);
+        starterPage.setERDiagram("Inventory System", true, "domain", false, "service", false, "resource", true);
         starterPage.openERDiagramPreview();
         starterPage.checkDiagramCodeContains("PRODUCT ||--o{ INVENTORY : contains");
         starterPage.checkDiagramGraphContains("INVENTORY");
         starterPage.closeERDiagramPreview();
         starterPage.setSecurity("None");
-        starterPage.generate(page, Paths.get("./target", "InventorySystemTest.zip"));
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "InventorySystemTest.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/InventorySystemTest.zip", "./target/test-app-maven/InventorySystemTest");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/InventorySystemTest/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/InventorySystemTest/pom.xml"),
+                "<maven.compiler.release>11</maven.compiler.release>"));
     }
 }

--- a/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/GenerationAppIT.java
+++ b/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/GenerationAppIT.java
@@ -67,6 +67,7 @@ public class GenerationAppIT {
     void openPage() {
         context = browser.newContext();
         page = context.newPage();
+        page.setDefaultTimeout(90000);
         page.navigate("http://localhost:8080/payara-starter");
         page.waitForSelector("div.hero", new Page.WaitForSelectorOptions().setTimeout(120000));
 
@@ -83,11 +84,31 @@ public class GenerationAppIT {
     static void closeBrowser() {
         playwright.close();
     }
+
+    @Test
+    void gradleJdk11HelloWorld() throws InterruptedException, IOException {
+        assertThat(page).hasTitle("Generate Payara Application");
+        starterPage.setProjectDescription("Gradle", "fish.payara.playwright.test", "HelloWorldJdk11", "1.0");
+        starterPage.setJakartaEE("Jakarta EE 8", "8", "Web Profile");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Micro", "5.2022.5", "5.2022.5");
+        starterPage.setProjectConfiguration("fish.payara.e2e", false, "Java SE 11", "11");
+        starterPage.setMicroProfile("Full MP");
+        starterPage.setDeployment(true, false);
+        starterPage.setERDiagram("", true, "domain", false, "service", false, "resource", true);
+        starterPage.setSecurity("Form Authentication - File Realm");
+        starterPage.generate(page, Paths.get("./target/test-app-gradle", "HelloWorldJdk11.zip"));
+
+        FileManagement.unzip("./target/test-app-gradle/HelloWorldJdk11.zip", "./target/test-app-gradle/HelloWorldJdk11");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-gradle/HelloWorldJdk11/build.gradle")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-gradle/HelloWorldJdk11/build.gradle"),
+                "sourceCompatibility = JavaVersion.VERSION_11"));
+    }
     
     @Test
-    void shouldGenerateSimpleApp() throws InterruptedException, IOException {
+    void gradleJdk17HelloWorld() throws InterruptedException, IOException {
         assertThat(page).hasTitle("Generate Payara Application");
-        starterPage.setProjectDescription("Gradle", "fish.payara.playwright.test", "PlaywrightTest", "1.0");
+        starterPage.setProjectDescription("Gradle", "fish.payara.playwright.test", "HelloWorldJdk17", "1.0");
         starterPage.setJakartaEE("Jakarta EE 9.1", "9.1", "Web Profile");
         starterPage.closeGuidePopup();
         starterPage.setPayaraPlatform("Payara Micro", "6.2025.1", "6.2025.1");
@@ -96,17 +117,36 @@ public class GenerationAppIT {
         starterPage.setDeployment(true, false);
         starterPage.setERDiagram("", true, "domain", false, "service", false, "resource", true);
         starterPage.setSecurity("Form Authentication - File Realm");
-        starterPage.generate(page, Paths.get("./target/test-app-gradle", "PlaywrightTest.zip"));
+        starterPage.generate(page, Paths.get("./target/test-app-gradle", "HelloWorldJdk17.zip"));
 
-        FileManagement.unzip("./target/test-app-gradle/PlaywrightTest.zip", "./target/test-app-gradle/PlaywrightTest");
-        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-gradle/PlaywrightTest/build.gradle")));
-        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-gradle/PlaywrightTest/build.gradle"),
+        FileManagement.unzip("./target/test-app-gradle/HelloWorldJdk17.zip", "./target/test-app-gradle/HelloWorldJdk17");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-gradle/HelloWorldJdk17/build.gradle")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-gradle/HelloWorldJdk17/build.gradle"),
                 "sourceCompatibility = JavaVersion.VERSION_17"));
-
     }
 
+    /*@Test
+    @Disable("provided gradle wrapper fails to compile with jdk21 - FISH-11064")
+    void gradleJdk21HelloWorld() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Gradle", "fish.payara.playwright.test", "PlaywrightTest2", "2.0");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Web Profile");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Micro", "6.2025.1", "6.2025.1");
+        starterPage.setProjectConfiguration("fish.payara.e2e", false, "Java SE 21", "21");
+        starterPage.setMicroProfile("Full MP");
+        starterPage.setDeployment(true, false);
+        starterPage.setERDiagram("", true, "domain", false, "service", false, "resource", true);
+        starterPage.setSecurity("Form Authentication - File Realm");
+        starterPage.generate(page, Paths.get("./target/test-app-gradle", "HelloWorldJdk21.zip"));
+
+        FileManagement.unzip("./target/test-app-gradle/HelloWorldJdk21.zip", "./target/test-app-gradle/HelloWorldJdk21");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-gradle/HelloWorldJdk21/build.gradle")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-gradle/HelloWorldJdk21/build.gradle"),
+                "sourceCompatibility = JavaVersion.VERSION_21"));
+    }*/
+
     @Test
-    void shouldModifyAppWithERDiagram() throws InterruptedException, IOException {
+    void mavenJdk11InventorySystem() throws InterruptedException, IOException {
         starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "InventorySystemTest", "1.0-SNAPSHOT");
         starterPage.setJakartaEE("Jakarta EE 8", "8", "Web Profile");
         starterPage.closeGuidePopup();
@@ -120,11 +160,49 @@ public class GenerationAppIT {
         starterPage.checkDiagramGraphContains("INVENTORY");
         starterPage.closeERDiagramPreview();
         starterPage.setSecurity("None");
-        starterPage.generate(page, Paths.get("./target/test-app-maven", "InventorySystemTest.zip"));
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "InventorySystemTestJdk11.zip"));
 
-        FileManagement.unzip("./target/test-app-maven/InventorySystemTest.zip", "./target/test-app-maven/InventorySystemTest");
-        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/InventorySystemTest/pom.xml")));
-        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/InventorySystemTest/pom.xml"),
+        FileManagement.unzip("./target/test-app-maven/InventorySystemTestJdk11.zip", "./target/test-app-maven/InventorySystemTestJdk11");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/InventorySystemTestJdk11/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/InventorySystemTestJdk11/pom.xml"),
                 "<maven.compiler.release>11</maven.compiler.release>"));
     }
+
+    @Test
+    void mavenJdk17ProductCatalog() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "ProductCatalog", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 9", "9", "Web Profile");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Server", "6.2025.1", "6.2025.1");
+        starterPage.setProjectConfiguration("fish.payara.e2e", true, "Java SE 17", "17");
+        starterPage.setMicroProfile("MicroProfile Metrics");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("Product Catalog", true, "domain", false, "service", false, "resource", true);
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "ProductCatalogJdk17.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/ProductCatalogJdk17.zip", "./target/test-app-maven/ProductCatalogJdk17");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/ProductCatalogJdk17/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/ProductCatalogJdk17/pom.xml"),
+                "<maven.compiler.release>17</maven.compiler.release>"));
+    }
+
+    /*@Test
+    void mavenJdk21EnergyManagementSystem() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "EnergyManagementSystem", "1.1");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Web Profile");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Server", "6.2024.12", "6.2024.12");
+        starterPage.setProjectConfiguration("fish.payara.e2e", true, "Java SE 21", "21");
+        starterPage.setMicroProfile("MicroProfile Metrics");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("Energy Management System", false, "domain", false, "service", false, "resource", true);
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "EnergyManagementSystemJdk21.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/EnergyManagementSystemJdk21.zip", "./target/test-app-maven/EnergyManagementSystemJdk21");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/EnergyManagementSystemJdk21/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/EnergyManagementSystemJdk21/pom.xml"),
+                "<maven.compiler.release>21</maven.compiler.release>"));
+    }*/
 }

--- a/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/GenerationAppIT.java
+++ b/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/GenerationAppIT.java
@@ -108,7 +108,7 @@ public class GenerationAppIT {
     @Test
     void gradleJdk17HelloWorld() throws InterruptedException, IOException {
         assertThat(page).hasTitle("Generate Payara Application");
-        starterPage.setProjectDescription("Gradle", "fish.payara.playwright.test", "HelloWorldJdk17", "1.0");
+        starterPage.setProjectDescription("Gradle", "fish.payara.playwright.test", "HelloWorldJdk17", "1.7");
         starterPage.setJakartaEE("Jakarta EE 9.1", "9.1", "Web Profile");
         starterPage.closeGuidePopup();
         starterPage.setPayaraPlatform("Payara Micro", "6.2025.1", "6.2025.1");
@@ -126,9 +126,9 @@ public class GenerationAppIT {
     }
 
     /*@Test
-    @Disable("provided gradle wrapper fails to compile with jdk21 - FISH-11064")
+    // Disabled - provided gradle wrapper fails to compile with jdk21 - FISH-11064"
     void gradleJdk21HelloWorld() throws InterruptedException, IOException {
-        starterPage.setProjectDescription("Gradle", "fish.payara.playwright.test", "PlaywrightTest2", "2.0");
+        starterPage.setProjectDescription("Gradle", "fish.payara.playwright.test", "HelloWorldJdk21", "2.0");
         starterPage.setJakartaEE("Jakarta EE 10", "10", "Web Profile");
         starterPage.closeGuidePopup();
         starterPage.setPayaraPlatform("Payara Micro", "6.2025.1", "6.2025.1");
@@ -147,7 +147,7 @@ public class GenerationAppIT {
 
     @Test
     void mavenJdk11InventorySystem() throws InterruptedException, IOException {
-        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "InventorySystemTest", "1.0-SNAPSHOT");
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "InventorySystemTestJdk11", "1.0-SNAPSHOT");
         starterPage.setJakartaEE("Jakarta EE 8", "8", "Web Profile");
         starterPage.closeGuidePopup();
         starterPage.setPayaraPlatform("Payara Server", "5.2022.5", "5.2022.5");
@@ -170,7 +170,7 @@ public class GenerationAppIT {
 
     @Test
     void mavenJdk17ProductCatalog() throws InterruptedException, IOException {
-        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "ProductCatalog", "1.0-SNAPSHOT");
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "ProductCatalogJdk17", "1.0-SNAPSHOT");
         starterPage.setJakartaEE("Jakarta EE 9", "9", "Web Profile");
         starterPage.closeGuidePopup();
         starterPage.setPayaraPlatform("Payara Server", "6.2025.1", "6.2025.1");
@@ -188,8 +188,10 @@ public class GenerationAppIT {
     }
 
     /*@Test
+    // Disabled - provided gradle wrapper fails to compile with jdk21 - FISH-11064
+    So we need to run the tests with jdk 17
     void mavenJdk21EnergyManagementSystem() throws InterruptedException, IOException {
-        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "EnergyManagementSystem", "1.1");
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "EnergyManagementSystemJdk21", "1.0-SNAPSHOT");
         starterPage.setJakartaEE("Jakarta EE 10", "10", "Web Profile");
         starterPage.closeGuidePopup();
         starterPage.setPayaraPlatform("Payara Server", "6.2024.12", "6.2024.12");

--- a/starter-ui/src/test/java/fish/payara/starter/test/e2e/utils/FileManagement.java
+++ b/starter-ui/src/test/java/fish/payara/starter/test/e2e/utils/FileManagement.java
@@ -1,0 +1,90 @@
+/*
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.starter.test.e2e.utils;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipEntry;
+
+public class FileManagement {
+
+    // Unzip files
+    public static void unzip(String zipFile, String destFolder) throws IOException {
+        try (ZipInputStream zis = new ZipInputStream(new FileInputStream(zipFile))) {
+            ZipEntry entry;
+            byte[] buffer = new byte[1024];
+            while ((entry = zis.getNextEntry()) != null) {
+                File newFile = new File(destFolder + File.separator + entry.getName());
+                if (entry.isDirectory()) {
+                    newFile.mkdirs();
+                } else {
+                    new File(newFile.getParent()).mkdirs();
+                    try (FileOutputStream fos = new FileOutputStream(newFile)) {
+                        int length;
+                        while ((length = zis.read(buffer)) > 0) {
+                            fos.write(buffer, 0, length);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Check for the presence of a specified file in a folder recursively
+    public static boolean checkFilePresence(File file) throws IOException {
+        return (file.isFile() && !file.isDirectory());
+    };
+
+    // Check if a file contains a specified string
+    public static boolean checkFileContains(File file, String value) throws IOException {
+        boolean result = false;
+        BufferedReader reader = new BufferedReader(new FileReader(file));
+        while (reader.ready()) {
+            if (reader.readLine().contains(value)) {
+                result = true;
+            }
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
Upgrade to the tests for Payara starter.

Current issues: FISH-11064 - gradle build fails when using jdk21.

To run Payara Starter and the tests:
- Add an OpenAI key to the file {ecosystem-starter}/starter-ui/src/main/resources/META-INF/microprofile-config.properties, with `OPEN_API_KEY=XXXXXX`
- using jdk17, build the whole project {ecosystem-starter}/`mvn clean install`
- run the tests: {ecosystem-starter}/starter-ui/`mvn verify -De2e`

The tests generate several types of applications, then unzip the generated apps, check for the presence of specific files and the content (if necessary), and finally, 2 maven steps run bits of scripts to compile the generated apps via maven and gradle.
If one build fails, the tests fail.

To follow: FISH-10904 - add more scenarios to cover more combinations and edge cases with the generated apps.
FISH-11021 - integrate these tests in the pipeline in Jenkins
FISH-10902 - add tests for starter-archetypes (this is independent from these tests)