### PR TITLE
FISH-10972 JSF template support - basic attributes

### DIFF
--- a/starter-generator/src/main/resources/template/jsf/EntityBean.java.ftl
+++ b/starter-generator/src/main/resources/template/jsf/EntityBean.java.ftl
@@ -1,0 +1,69 @@
+<#-- 
+    Copyright 2024 the original author or authors from the Jeddict project (https://jeddict.github.io/).
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not
+    use this file except in compliance with the License. You may obtain a copy of
+    the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations under
+    the License.
+-->
+package ${package};
+
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Named;
+import jakarta.inject.Inject;
+import jakarta.faces.view.ViewScoped;
+import java.io.Serializable;
+import java.util.List;
+
+import ${EntityClass_FQN};
+import ${EntityRepository_FQN};
+
+@Named("${beanName}")
+@ViewScoped
+public class ${beanClass} implements Serializable {
+
+    @Inject
+    private transient ${EntityRepository} ${entityRepository};
+
+    private ${EntityClass} ${entityInstance} = new ${EntityClass}();
+
+    public ${EntityClass} get${EntityClass}() {
+        return ${entityInstance};
+    }
+
+    public List<${EntityClass}> getAll${EntityClassPlural}() {
+        return ${entityRepository}.findAll();
+    }
+
+    public String create() {
+      
+        return null;
+    }
+    public String save() {
+        if (${entityInstance}.${pkGetter}() == null) {
+             ${entityRepository}.create(${entityInstance});
+        } else {
+             ${entityRepository}.edit(${entityInstance});
+        }
+        ${entityInstance} = new ${EntityClass}(); // reset
+        return null;
+    }
+
+    public String remove(${pkType} ${pkName}) {
+        ${entityRepository}.remove(${entityRepository}.find(${pkName}));
+        return null;
+    }
+
+    public String edit(${EntityClass} p) {
+        this.${entityInstance} = p;
+        return null;
+    }
+
+}

--- a/starter-generator/src/main/resources/template/jsf/entity.xhtml.ftl
+++ b/starter-generator/src/main/resources/template/jsf/entity.xhtml.ftl
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:f="jakarta.faces.core"
+      xmlns:h="jakarta.faces.html">
+<h:head>
+    <title>${entity.getTitle()}</title>
+</h:head>
+<h:body>
+    <h:form>
+        <h3>${entity.getTitle()}</h3>
+        <p>${entity.getDescription()}</p>
+        <h:panelGrid columns="2">
+            <#list entity.attributes as attribute>
+                <#if !attribute.multi>
+                    <h:outputLabel for="${attribute.getName()}" value="${attribute.getStartCaseName()}:" />
+                    <h:inputText id="${attribute.getName()}" value="${'#' + '{'+ beanName + '.' + entityNameLowerCase + '.' + attribute.name + '}'}" />
+                </#if>
+            </#list>
+        </h:panelGrid>
+
+        <h:commandButton value="Save" action="${'#' + '{'+ beanName + '.save}'}" />
+
+        <h3>${entity.getTitle()} List</h3>
+        <h:dataTable value="${'#' + '{'+ beanName + '.all'+entityNameTitleCasePluralize+'}'}" var="${entityNameLowerCase}" border="1">
+            <#list entity.attributes as attribute>
+                <#if !attribute.multi>
+                    <h:column>
+                        <f:facet name="header">${attribute.getStartCaseName()}</f:facet>
+                        ${'#' + '{' + entityNameLowerCase + '.' + attribute.name + '}'}
+                    </h:column>
+                </#if>
+            </#list>
+            <h:column>
+                <f:facet name="header">Actions</f:facet>
+                <h:commandLink value="Edit" action="${'#' + '{'+ beanName + '.edit(' + entityNameLowerCase + ')}'}" />
+                |
+                <h:commandLink value="Delete" action="${'#' + '{'+ beanName + '.remove(' + entityNameLowerCase + '.' + pkName + ')}'}"
+                               onclick="return confirm('Delete this ${entityNameLowerCase}?');" />
+            </h:column>
+        </h:dataTable>
+    </h:form>
+</h:body>
+</html>

--- a/starter-ui/src/main/java/fish/payara/starter/resources/ApplicationConfiguration.java
+++ b/starter-ui/src/main/java/fish/payara/starter/resources/ApplicationConfiguration.java
@@ -169,7 +169,7 @@ public class ApplicationConfiguration {
     private boolean generateJPA = true;
     private boolean generateRepository = true;
     private boolean generateRest = true;
-    private boolean generateWeb = true;
+    private String generateWeb;
     private String jpaSubpackage = "domain";
     private String repositorySubpackage = "service";
     private String restSubpackage = "resource";
@@ -434,11 +434,11 @@ public class ApplicationConfiguration {
         this.generateRest = generateRest;
     }
 
-    public boolean isGenerateWeb() {
+    public String getGenerateWeb() {
         return generateWeb;
     }
 
-    public void setGenerateWeb(boolean generateWeb) {
+    public void setGenerateWeb(String generateWeb) {
         this.generateWeb = generateWeb;
     }
 

--- a/starter-ui/src/main/java/fish/payara/starter/resources/ApplicationGenerator.java
+++ b/starter-ui/src/main/java/fish/payara/starter/resources/ApplicationGenerator.java
@@ -162,7 +162,7 @@ public class ApplicationGenerator {
                                 appProperties.isGenerateJPA(),
                                 appProperties.isGenerateRepository(),
                                 appProperties.isGenerateRest(),
-                                appProperties.isGenerateWeb());
+                                appProperties.getGenerateWeb());
                     } catch (Exception e) {
                         LOGGER.log(Level.SEVERE, "Error generating application: " + e.getMessage(), e);
                     }

--- a/starter-ui/src/main/webapp/index.html
+++ b/starter-ui/src/main/webapp/index.html
@@ -452,8 +452,12 @@
                                                             <label class="form__label" for="restSubpackage">Package</label>
                                                             <input class="form__textfield" type="text" id="restSubpackage" name="restSubpackage" value="resource" placeholder="Subpackage for REST" title="Specify the subpackage for REST">
                                                             <br><br>
-                                                                <input class="form__radbox" type="checkbox" id="generateWeb" name="generateWeb" value="true" checked title="Generate Web code">
-                                                                <label class="form__radbox-label" for="generateWeb">Web</label>
+                                                            <label for="generateWeb" class="form__radbox-label">Web</label>
+                                                            <select class="form__select" id="generateWeb" name="generateWeb" title="Generate Web code">
+                                                              <option value="none">None</option>
+                                                              <option value="html">HTML</option>
+                                                              <option value="jsf" selected>JSF</option>
+                                                            </select>
                                                         </p>
 
                                                         <p class="form__row form-steps__controls">
@@ -1108,7 +1112,7 @@
                 const jpaCheckbox = document.getElementById('generateJpa');
                 const repositoryCheckbox = document.getElementById('generateRepository');
                 const restCheckbox = document.getElementById('generateRest');
-                const htmlCheckbox = document.getElementById('generateWeb');
+                const generateWeb = document.getElementById('generateWeb');
 
                 repositoryCheckbox.addEventListener('change', function () {
                     if (repositoryCheckbox.checked) {
@@ -1123,8 +1127,8 @@
                     }
                 });
 
-                htmlCheckbox.addEventListener('change', function () {
-                    if (htmlCheckbox.checked) {
+                generateWeb.addEventListener('change', function () {
+                    if (generateWeb.value !== 'none') {
                         jpaCheckbox.checked = true;
                         repositoryCheckbox.checked = true;
                         restCheckbox.checked = true;
@@ -1135,20 +1139,20 @@
                     if (!jpaCheckbox.checked) {
                         repositoryCheckbox.checked = false;
                         restCheckbox.checked = false;
-                        htmlCheckbox.checked = false;
+                        generateWeb.value = 'none'; 
                     }
                 });
 
                 repositoryCheckbox.addEventListener('change', function () {
                     if (!repositoryCheckbox.checked) {
                         restCheckbox.checked = false;
-                        htmlCheckbox.checked = false;
+                        generateWeb.value = 'none'; 
                     }
                 });
 
                 restCheckbox.addEventListener('change', function () {
                     if (!restCheckbox.checked) {
-                        htmlCheckbox.checked = false;
+                        generateWeb.value = 'none'; 
                     }
                 });
             }


### PR DESCRIPTION
This PR adds a feature to create a JSF application from an ER diagram.

To test it, open the Payara Starter page, select ER Diagram, then in the Web section, choose JSF and generate the application. Currently, the generated JSF page for the entity does not include any CSS, so it may not look visually appealing. However, you can still perform CRUD operations on the page. 
![jsf-template1](https://github.com/user-attachments/assets/d0c22e78-31d6-4126-8924-a7f3e13c02c7)
