### PR TITLE
FISH-10904 e2e test scenarios

### DIFF
--- a/starter-ui/pom.xml
+++ b/starter-ui/pom.xml
@@ -216,8 +216,10 @@
                 <version>2.4</version>
                 <configuration>
                     <commandLineOptions>
+                        <!-- we use port 8082 to run the e2e tests -->
                         <option>
-                            <key>--autoBindHttp</key>
+                            <key>--port</key>
+                            <value>8082</value>
                         </option>
                     </commandLineOptions>
                 </configuration>
@@ -287,7 +289,7 @@
                                     <arguments>
                                         <argument>
                                             <![CDATA[
-                                        Get-ChildItem -Path ./target/test-app-maven -Directory | ForEach-Object { Push-Location $_.FullName; & mvn compile -f pom.xml; Pop-Location }
+                                        Get-ChildItem -Path ./target/test-app-maven -Directory | ForEach-Object { Push-Location $_.FullName; & mvn verify -f pom.xml; Pop-Location }
                                             ]]>
                                         </argument>
                                     </arguments>
@@ -360,7 +362,7 @@
                                             <![CDATA[
                                             for dir in ./target/test-app-maven/*; do 
                                                 if [ -d "$dir" ]; then 
-                                                    (cd "$dir" && mvn compile); 
+                                                    (cd "$dir" && mvn verify
                                                 fi; 
                                             done
                                             ]]>

--- a/starter-ui/src/test/java/fish/payara/starter/test/e2e/pages/StarterPageActions.java
+++ b/starter-ui/src/test/java/fish/payara/starter/test/e2e/pages/StarterPageActions.java
@@ -195,8 +195,10 @@ public class StarterPageActions {
     }
 
     public void selectMicroProfile(String value) {
+        if (!value.isEmpty()) {
         locators.microProfileBlock.get().getByText(value).click();
-        PlaywrightAssertions.assertThat(locators.microProfileBlock.get().getByText(value)).isChecked();
+            PlaywrightAssertions.assertThat(locators.microProfileBlock.get().getByText(value)).isChecked();
+        }
     }
 
     public void setMicroProfile(String value) throws InterruptedException {

--- a/starter-ui/src/test/java/fish/payara/starter/test/e2e/pages/StarterPageActions.java
+++ b/starter-ui/src/test/java/fish/payara/starter/test/e2e/pages/StarterPageActions.java
@@ -356,7 +356,7 @@ public class StarterPageActions {
 
 
     public void generate(Page page, Path filepath) {
-        Download download = page.waitForDownload(new Page.WaitForDownloadOptions().setTimeout(90000), () -> {
+        Download download = page.waitForDownload(new Page.WaitForDownloadOptions().setTimeout(120000), () -> {
             locators.generateButton.get().click();
         });
         download.saveAs(filepath);

--- a/starter-ui/src/test/java/fish/payara/starter/test/e2e/pages/StarterPageActions.java
+++ b/starter-ui/src/test/java/fish/payara/starter/test/e2e/pages/StarterPageActions.java
@@ -287,15 +287,13 @@ public class StarterPageActions {
         PlaywrightAssertions.assertThat(locators.restSubpackage.get()).hasValue(value);
     }
 
-    public void enableGenerateWeb() {
-        if (!locators.generateWeb.get().isChecked()) {
-            locators.generateWeb.get().click();
-        }
-        PlaywrightAssertions.assertThat(locators.generateWeb.get()).isChecked();
+    public void selectGenerateWeb(String text, String value) {
+        locators.generateWeb.get().selectOption(text);
+        PlaywrightAssertions.assertThat(locators.generateWeb.get()).hasValue(value);
     }
 
     public void setERDiagram(String ERDiagram, Boolean generateJPA, String jpaPackage, Boolean generateRepository,
-            String repoPackage, Boolean generateRest, String restPackage, Boolean generateWeb)
+            String repoPackage, Boolean generateRest, String restPackage, String webText, String webValue)
             throws InterruptedException {
         goToDiagramSection();
         selectERDiagram(ERDiagram);
@@ -311,9 +309,7 @@ public class StarterPageActions {
             enableGenerateRest();
         }
         setRestPackage(restPackage);
-        if (generateWeb) {
-            enableGenerateWeb();
-        }
+        selectGenerateWeb(webText, webValue);
     }
 
     // Diagram Builder & Live Preview

--- a/starter-ui/src/test/java/fish/payara/starter/test/e2e/pages/StarterPageLocators.java
+++ b/starter-ui/src/test/java/fish/payara/starter/test/e2e/pages/StarterPageLocators.java
@@ -78,7 +78,7 @@ public class StarterPageLocators {
     public final Supplier<Locator> jakartaeeBlock = () -> page.locator("fieldset#stb0-st1");
     public final Supplier<Locator> jakartaeeBlockTitle = () -> jakartaeeBlock.get().locator("div.legend a[href='#stb0-st1']");
     public final Supplier<Locator> jarkataeeVersion = () -> jakartaeeBlock.get().locator("select#jakartaEEVersion");
-    public final Supplier<Locator> jakartaeeProfile = () -> jakartaeeBlock.get();
+    public final Supplier<Locator> jakartaeeProfile = () -> jakartaeeBlock.get().locator("label.form__radbox-label");
     public final Supplier<Locator> previousButtonToPayaraPlatform = () -> jakartaeeBlock.get().locator("a[href='#stb0-st0']");
     public final Supplier<Locator> nextButtonToPayaraPlatform = () -> jakartaeeBlock.get().locator("a[href='#stb0-st2']");
 

--- a/starter-ui/src/test/java/fish/payara/starter/test/e2e/pages/StarterPageLocators.java
+++ b/starter-ui/src/test/java/fish/payara/starter/test/e2e/pages/StarterPageLocators.java
@@ -134,7 +134,7 @@ public class StarterPageLocators {
     public final Supplier<Locator> repositorySubpackage = () -> diagramBlock.get().locator("input#repositorySubpackage");
     public final Supplier<Locator> generateRest = () -> diagramBlock.get().locator("input#generateRest");
     public final Supplier<Locator> restSubpackage = () -> diagramBlock.get().locator("input#restSubpackage");
-    public final Supplier<Locator> generateWeb = () -> diagramBlock.get().locator("input#generateWeb");
+    public final Supplier<Locator> generateWeb = () -> diagramBlock.get().locator("select#generateWeb");
     public final Supplier<Locator> previousButtonToSecurity = () -> diagramBlock.get().locator("a[href='#stb0-st5']");
     public final Supplier<Locator> nextButtonToSecurity = () -> diagramBlock.get().locator("a[href='#stb0-st7']");
 

--- a/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/DeploymentOptionsIT.java
+++ b/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/DeploymentOptionsIT.java
@@ -50,7 +50,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @UsePlaywright
 public class DeploymentOptionsIT {
-
     // Generates a simple application permuting the deployment options Docker/Payara Cloud
     private static Playwright playwright;
     private static Browser browser;
@@ -87,65 +86,40 @@ public class DeploymentOptionsIT {
     }
 
     @Test
-    void mavenJdk11InventorySystem() throws InterruptedException, IOException {
-        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "InventorySystemTestJdk11", "1.0-SNAPSHOT");
-        starterPage.setJakartaEE("Jakarta EE 8", "8", "Web Profile");
-        starterPage.closeGuidePopup();
+    void PayaraServer5EE8Jdk11Docker() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "PayaraServer5EE8Jdk11Docker", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 8", "8", "Platform");
         starterPage.setPayaraPlatform("Payara Server", "5.2022.5", "5.2022.5");
-        starterPage.setProjectConfiguration("fish.payara.e2e", true, "Java SE 11", "11");
-        starterPage.setMicroProfile("MicroProfile Metrics");
-        starterPage.setDeployment(false, false);
-        starterPage.setERDiagram("Inventory System", true, "domain", false, "service", false, "resource", "HTML", "html");
-        starterPage.openERDiagramPreview();
-        starterPage.checkDiagramCodeContains("PRODUCT ||--o{ INVENTORY : contains");
-        starterPage.checkDiagramGraphContains("INVENTORY");
-        starterPage.closeERDiagramPreview();
+        starterPage.closeGuidePopup();
+        starterPage.setProjectConfiguration("fish.payara.test", false, "Java SE 11", "11");
+        starterPage.setMicroProfile("");
+        starterPage.setDeployment(true, false);
+        starterPage.setERDiagram("", false, "domain", false, "service", false, "resource", "None", "none");
         starterPage.setSecurity("None");
-        starterPage.generate(page, Paths.get("./target/test-app-maven", "InventorySystemTestJdk11.zip"));
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "PayaraServer5EE8Jdk11Docker.zip"));
 
-        FileManagement.unzip("./target/test-app-maven/InventorySystemTestJdk11.zip", "./target/test-app-maven/InventorySystemTestJdk11");
-        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/InventorySystemTestJdk11/pom.xml")));
-        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/InventorySystemTestJdk11/pom.xml"),
+        FileManagement.unzip("./target/test-app-maven/PayaraServer5EE8Jdk11Docker.zip", "./target/test-app-maven/PayaraServer5EE8Jdk11Docker");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/PayaraServer5EE8Jdk11Docker/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/PayaraServer5EE8Jdk11Docker/pom.xml"),
                 "<maven.compiler.release>11</maven.compiler.release>"));
     }
 
     @Test
-    void mavenJdk17ProductCatalog() throws InterruptedException, IOException {
-        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "ProductCatalogJdk17", "1.0-SNAPSHOT");
-        starterPage.setJakartaEE("Jakarta EE 9", "9", "Web Profile");
-        starterPage.closeGuidePopup();
+    void PayaraServer6EE10Jdk17Cloud() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "PayaraServer6EE10Jdk17Cloud", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Platform");
         starterPage.setPayaraPlatform("Payara Server", "6.2025.1", "6.2025.1");
-        starterPage.setProjectConfiguration("fish.payara.e2e", true, "Java SE 17", "17");
-        starterPage.setMicroProfile("MicroProfile Metrics");
-        starterPage.setDeployment(false, false);
-        starterPage.setERDiagram("Product Catalog", true, "domain", false, "service", false, "resource", "HTML", "html");
+        starterPage.closeGuidePopup();
+        starterPage.setProjectConfiguration("fish.payara.test", false, "Java SE 17", "17");
+        starterPage.setMicroProfile("");
+        starterPage.setDeployment(false, true);
+        starterPage.setERDiagram("", false, "domain", false, "service", false, "resource", "None", "none");
         starterPage.setSecurity("None");
-        starterPage.generate(page, Paths.get("./target/test-app-maven", "ProductCatalogJdk17.zip"));
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "PayaraServer6EE10Jdk17Cloud.zip"));
 
-        FileManagement.unzip("./target/test-app-maven/ProductCatalogJdk17.zip", "./target/test-app-maven/ProductCatalogJdk17");
-        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/ProductCatalogJdk17/pom.xml")));
-        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/ProductCatalogJdk17/pom.xml"),
+        FileManagement.unzip("./target/test-app-maven/PayaraServer6EE10Jdk17Cloud.zip", "./target/test-app-maven/PayaraServer6EE10Jdk17Cloud");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/PayaraServer6EE10Jdk17Cloud/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/PayaraServer6EE10Jdk17Cloud/pom.xml"),
                 "<maven.compiler.release>17</maven.compiler.release>"));
     }
-
-    /*@Test
-    // Disabled - provided gradle wrapper fails to compile with jdk21 - FISH-11064
-    So we need to run the tests with jdk 17
-    void mavenJdk21EnergyManagementSystem() throws InterruptedException, IOException {
-        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "EnergyManagementSystemJdk21", "1.0-SNAPSHOT");
-        starterPage.setJakartaEE("Jakarta EE 10", "10", "Web Profile");
-        starterPage.closeGuidePopup();
-        starterPage.setPayaraPlatform("Payara Server", "6.2024.12", "6.2024.12");
-        starterPage.setProjectConfiguration("fish.payara.e2e", true, "Java SE 21", "21");
-        starterPage.setMicroProfile("MicroProfile Metrics");
-        starterPage.setDeployment(false, false);
-        starterPage.setERDiagram("Energy Management System", false, "domain", false, "service", false, "resource", "HTML", "html");
-        starterPage.setSecurity("None");
-        starterPage.generate(page, Paths.get("./target/test-app-maven", "EnergyManagementSystemJdk21.zip"));
-
-        FileManagement.unzip("./target/test-app-maven/EnergyManagementSystemJdk21.zip", "./target/test-app-maven/EnergyManagementSystemJdk21");
-        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/EnergyManagementSystemJdk21/pom.xml")));
-        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/EnergyManagementSystemJdk21/pom.xml"),
-                "<maven.compiler.release>21</maven.compiler.release>"));
-    }*/
 }

--- a/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/DeploymentOptionsIT.java
+++ b/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/DeploymentOptionsIT.java
@@ -68,7 +68,7 @@ public class DeploymentOptionsIT {
         context = browser.newContext();
         page = context.newPage();
         page.setDefaultTimeout(90000);
-        page.navigate("http://localhost:8080/payara-starter");
+        page.navigate("http://localhost:8082/payara-starter");
         page.waitForSelector("div.hero", new Page.WaitForSelectorOptions().setTimeout(120000));
 
         starterPage = new StarterPageActions(page);

--- a/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/DeploymentOptionsIT.java
+++ b/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/DeploymentOptionsIT.java
@@ -1,0 +1,151 @@
+/*
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.starter.test.e2e.specs;
+
+import com.microsoft.playwright.*;
+import com.microsoft.playwright.junit.UsePlaywright;
+import fish.payara.starter.test.e2e.pages.*;
+import fish.payara.starter.test.e2e.utils.FileManagement;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@UsePlaywright
+public class DeploymentOptionsIT {
+
+    // Generates a simple application permuting the deployment options Docker/Payara Cloud
+    private static Playwright playwright;
+    private static Browser browser;
+    private static BrowserContext context;
+    private static Page page;
+    private static StarterPageActions starterPage;
+
+    @BeforeAll
+    static void launchBrowser() {
+        playwright = Playwright.create();
+        browser = playwright.chromium().launch(new BrowserType.LaunchOptions().setHeadless(true));
+    }
+
+    @BeforeEach
+    void openPage() {
+        context = browser.newContext();
+        page = context.newPage();
+        page.setDefaultTimeout(90000);
+        page.navigate("http://localhost:8080/payara-starter");
+        page.waitForSelector("div.hero", new Page.WaitForSelectorOptions().setTimeout(120000));
+
+        starterPage = new StarterPageActions(page);
+        starterPage.confirmGdpr();
+    }
+
+    @AfterEach
+    void closePage() {
+        context.close();
+    }
+    
+    @AfterAll
+    static void closeBrowser() {
+        playwright.close();
+    }
+
+    @Test
+    void mavenJdk11InventorySystem() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "InventorySystemTestJdk11", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 8", "8", "Web Profile");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Server", "5.2022.5", "5.2022.5");
+        starterPage.setProjectConfiguration("fish.payara.e2e", true, "Java SE 11", "11");
+        starterPage.setMicroProfile("MicroProfile Metrics");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("Inventory System", true, "domain", false, "service", false, "resource", "HTML", "html");
+        starterPage.openERDiagramPreview();
+        starterPage.checkDiagramCodeContains("PRODUCT ||--o{ INVENTORY : contains");
+        starterPage.checkDiagramGraphContains("INVENTORY");
+        starterPage.closeERDiagramPreview();
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "InventorySystemTestJdk11.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/InventorySystemTestJdk11.zip", "./target/test-app-maven/InventorySystemTestJdk11");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/InventorySystemTestJdk11/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/InventorySystemTestJdk11/pom.xml"),
+                "<maven.compiler.release>11</maven.compiler.release>"));
+    }
+
+    @Test
+    void mavenJdk17ProductCatalog() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "ProductCatalogJdk17", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 9", "9", "Web Profile");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Server", "6.2025.1", "6.2025.1");
+        starterPage.setProjectConfiguration("fish.payara.e2e", true, "Java SE 17", "17");
+        starterPage.setMicroProfile("MicroProfile Metrics");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("Product Catalog", true, "domain", false, "service", false, "resource", "HTML", "html");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "ProductCatalogJdk17.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/ProductCatalogJdk17.zip", "./target/test-app-maven/ProductCatalogJdk17");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/ProductCatalogJdk17/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/ProductCatalogJdk17/pom.xml"),
+                "<maven.compiler.release>17</maven.compiler.release>"));
+    }
+
+    /*@Test
+    // Disabled - provided gradle wrapper fails to compile with jdk21 - FISH-11064
+    So we need to run the tests with jdk 17
+    void mavenJdk21EnergyManagementSystem() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "EnergyManagementSystemJdk21", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Web Profile");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Server", "6.2024.12", "6.2024.12");
+        starterPage.setProjectConfiguration("fish.payara.e2e", true, "Java SE 21", "21");
+        starterPage.setMicroProfile("MicroProfile Metrics");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("Energy Management System", false, "domain", false, "service", false, "resource", "HTML", "html");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "EnergyManagementSystemJdk21.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/EnergyManagementSystemJdk21.zip", "./target/test-app-maven/EnergyManagementSystemJdk21");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/EnergyManagementSystemJdk21/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/EnergyManagementSystemJdk21/pom.xml"),
+                "<maven.compiler.release>21</maven.compiler.release>"));
+    }*/
+}

--- a/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/FullStackAppIT.java
+++ b/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/FullStackAppIT.java
@@ -69,7 +69,7 @@ public class FullStackAppIT {
         context = browser.newContext();
         page = context.newPage();
         page.setDefaultTimeout(90000);
-        page.navigate("http://localhost:8080/payara-starter");
+        page.navigate("http://localhost:8082/payara-starter");
         page.waitForSelector("div.hero", new Page.WaitForSelectorOptions().setTimeout(120000));
 
         starterPage = new StarterPageActions(page);
@@ -87,8 +87,50 @@ public class FullStackAppIT {
     }
 
     @Test
-    void mavenJdk11InventorySystem() throws InterruptedException, IOException {
-        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "InventorySystemTestJdk11", "1.0-SNAPSHOT");
+    void productCatalogJdk8() throws InterruptedException, IOException {
+        // Build with Maven, EE8 Web profile, jdk8, Payara Server 5, Full MP, ER Diagram = Product Catalog, tests, Security DB
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "productCatalogJdk8", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 8", "8", "Web Profile");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Server", "5.2022.5", "5.2022.5");
+        starterPage.setProjectConfiguration("fish.payara.e2e", true, "Java SE 8", "8");
+        starterPage.setMicroProfile("Full MP");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("Product Catalog", true, "domain", true, "service", true, "resource", "HTML", "html");
+        starterPage.setSecurity("Form Authentication - Database");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "productCatalogJdk8.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/productCatalogJdk8.zip", "./target/test-app-maven/productCatalogJdk8");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/productCatalogJdk8/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/productCatalogJdk8/pom.xml"),
+                "<maven.compiler.target>1.8</maven.compiler.target>"));
+    }
+
+    /*@Test
+    // Disabled - gradle miss the ldap library - FISH-11339
+    void salesTrackingJdk8() throws InterruptedException, IOException {
+        // Build with Gradle, EE8 Full, jdk8, Payara Micro 5, Full MP, ER Diagram = Sales Tracking, no test, Security LDAP
+        starterPage.setProjectDescription("Gradle", "fish.payara.playwright.test", "salesTrackingJdk8", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 8", "8", "Platform");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Micro", "5.2022.5", "5.2022.5");
+        starterPage.setProjectConfiguration("fish.payara.e2e", true, "Java SE 8", "8");
+        starterPage.setMicroProfile("Full MP");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("Sales Tracking", true, "domain", true, "service", true, "resource", "HTML", "html");
+        starterPage.setSecurity("Form Authentication - LDAP");
+        starterPage.generate(page, Paths.get("./target/test-app-gradle", "salesTrackingJdk8.zip"));
+
+        FileManagement.unzip("./target/test-app-gradle/salesTrackingJdk8.zip", "./target/test-app-gradle/salesTrackingJdk8");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-gradle/salesTrackingJdk8/build.gradle")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-gradle/salesTrackingJdk8/build.gradle"),
+                "sourceCompatibility = 1.8"));
+    }*/
+
+    @Test
+    void inventorySystemJdk11() throws InterruptedException, IOException {
+        // Build with Maven, EE8, jdk11, Web Profile, Payara Server 5, MP Metrics, ER Diagram = Inventory System, tests
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "inventorySystemJdk11", "1.0-SNAPSHOT");
         starterPage.setJakartaEE("Jakarta EE 8", "8", "Web Profile");
         starterPage.closeGuidePopup();
         starterPage.setPayaraPlatform("Payara Server", "5.2022.5", "5.2022.5");
@@ -101,12 +143,378 @@ public class FullStackAppIT {
         starterPage.checkDiagramGraphContains("INVENTORY");
         starterPage.closeERDiagramPreview();
         starterPage.setSecurity("None");
-        starterPage.generate(page, Paths.get("./target/test-app-maven", "InventorySystemTestJdk11.zip"));
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "inventorySystemJdk11.zip"));
 
-        FileManagement.unzip("./target/test-app-maven/InventorySystemTestJdk11.zip", "./target/test-app-maven/InventorySystemTestJdk11");
-        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/InventorySystemTestJdk11/pom.xml")));
-        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/InventorySystemTestJdk11/pom.xml"),
+        FileManagement.unzip("./target/test-app-maven/inventorySystemJdk11.zip", "./target/test-app-maven/inventorySystemJdk11");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/inventorySystemJdk11/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/inventorySystemJdk11/pom.xml"),
                 "<maven.compiler.release>11</maven.compiler.release>"));
+    }
+
+    @Test
+    void flightReservationSystemJdk17() throws InterruptedException, IOException {
+        // Build with Maven, EE10 Web Profile, jdk17, Payara Micro 6, MP Metrics + Fault Tolerance, Payara Cloud, ER Diagram = Flight Reservation System, include tests, no security
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "flightReservationSystemJdk17", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Web Profile");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Server", "6.2025.5", "6.2025.5");
+        starterPage.setProjectConfiguration("fish.payara.e2e", true, "Java SE 17", "17");
+        starterPage.setMicroProfile("MicroProfile Metrics");
+        starterPage.setMicroProfile("MicroProfile Fault Tolerance");
+        starterPage.setDeployment(false, true);
+        starterPage.setERDiagram("Flight Reservation System", true, "domain", true, "service", true, "resource", "HTML", "html");
+        starterPage.openERDiagramPreview();
+        starterPage.checkDiagramCodeContains("FLIGHT ||--o{ RESERVATION : ");
+        starterPage.checkDiagramGraphContains("PASSENGER");
+        starterPage.closeERDiagramPreview();
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "flightReservationSystemJdk17.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/flightReservationSystemJdk17.zip", "./target/test-app-maven/flightReservationSystemJdk17");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/flightReservationSystemJdk17/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/flightReservationSystemJdk17/pom.xml"),
+                "<maven.compiler.release>17</maven.compiler.release>"));
+    }
+
+    // test the different templates
+    @Test
+    void auctionManagementSystemJdk17() throws InterruptedException, IOException {
+        // Build with Maven, EE10 Full profile, jdk17, Payara Micro 6, no MP, ER Diagram = Auction Management System, include tests, no security
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "auctionManagementSystemJdk17", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Platform");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Server", "6.2025.5", "6.2025.5");
+        starterPage.setProjectConfiguration("fish.payara.e2e", false, "Java SE 17", "17");
+        starterPage.setMicroProfile("");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("Auction Management System", true, "domain", true, "service", true, "resource", "HTML", "html");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "auctionManagementSystemJdk17.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/auctionManagementSystemJdk17.zip", "./target/test-app-maven/auctionManagementSystemJdk17");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/auctionManagementSystemJdk17/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/auctionManagementSystemJdk17/pom.xml"),
+                "<maven.compiler.release>17</maven.compiler.release>"));
+    }
+
+    @Test
+    void customerRelationshipManagementJdk17() throws InterruptedException, IOException {
+        // Build with Maven, EE10 Full profile, jdk17, Payara Micro 6, no MP, ER Diagram = Customer Relationship Management, include tests, no security
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "customerRelationshipManagementJdk17", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Platform");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Server", "6.2025.5", "6.2025.5");
+        starterPage.setProjectConfiguration("fish.payara.e2e", false, "Java SE 17", "17");
+        starterPage.setMicroProfile("");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("Customer Relationship Management", true, "domain", true, "service", true, "resource", "HTML", "html");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "customerRelationshipManagementJdk17.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/customerRelationshipManagementJdk17.zip", "./target/test-app-maven/customerRelationshipManagementJdk17");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/customerRelationshipManagementJdk17/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/customerRelationshipManagementJdk17/pom.xml"),
+                "<maven.compiler.release>17</maven.compiler.release>"));
+    }
+
+    @Test
+    void employeeManagementJdk17() throws InterruptedException, IOException {
+        // Build with Maven, EE10 Full profile, jdk17, Payara Micro 6, no MP, ER Diagram = Employee Management, include tests, no security
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "employeeManagementJdk17", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Platform");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Server", "6.2025.5", "6.2025.5");
+        starterPage.setProjectConfiguration("fish.payara.e2e", false, "Java SE 17", "17");
+        starterPage.setMicroProfile("");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("Employee Management", true, "domain", true, "service", true, "resource", "HTML", "html");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "employeeManagementJdk17.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/employeeManagementJdk17.zip", "./target/test-app-maven/employeeManagementJdk17");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/employeeManagementJdk17/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/employeeManagementJdk17/pom.xml"),
+                "<maven.compiler.release>17</maven.compiler.release>"));
+    }
+
+    @Test
+    void energyManagementSystemJdk17() throws InterruptedException, IOException {
+        // Build with Maven, EE10 Full profile, jdk17, Payara Micro 6, no MP, ER Diagram = Energy Management System, include tests, no security
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "energyManagementSystemJdk17", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Platform");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Server", "6.2025.5", "6.2025.5");
+        starterPage.setProjectConfiguration("fish.payara.e2e", false, "Java SE 17", "17");
+        starterPage.setMicroProfile("");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("Energy Management System", true, "domain", true, "service", true, "resource", "HTML", "html");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "energyManagementSystemJdk17.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/energyManagementSystemJdk17.zip", "./target/test-app-maven/energyManagementSystemJdk17");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/energyManagementSystemJdk17/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/energyManagementSystemJdk17/pom.xml"),
+                "<maven.compiler.release>17</maven.compiler.release>"));
+    }
+
+    @Test
+    void eventManagementJdk17() throws InterruptedException, IOException {
+        // Build with Maven, EE10 Full profile, jdk17, Payara Micro 6, no MP, ER Diagram = Event Management, include tests, no security
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "eventManagementJdk17", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Platform");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Server", "6.2025.5", "6.2025.5");
+        starterPage.setProjectConfiguration("fish.payara.e2e", false, "Java SE 17", "17");
+        starterPage.setMicroProfile("");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("Event Management", true, "domain", true, "service", true, "resource", "HTML", "html");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "eventManagementJdk17.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/eventManagementJdk17.zip", "./target/test-app-maven/eventManagementJdk17");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/eventManagementJdk17/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/eventManagementJdk17/pom.xml"),
+                "<maven.compiler.release>17</maven.compiler.release>"));
+    }
+
+    @Test
+    void healthcareSystemJdk17() throws InterruptedException, IOException {
+        // Build with Maven, EE10 Full profile, jdk17, Payara Micro 6, no MP, ER Diagram = Healthcare System, include tests, no security
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "healthcareSystemJdk17", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Platform");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Server", "6.2025.5", "6.2025.5");
+        starterPage.setProjectConfiguration("fish.payara.e2e", false, "Java SE 17", "17");
+        starterPage.setMicroProfile("");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("Healthcare System", true, "domain", true, "service", true, "resource", "HTML", "html");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "healthcareSystemJdk17.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/healthcareSystemJdk17.zip", "./target/test-app-maven/healthcareSystemJdk17");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/healthcareSystemJdk17/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/healthcareSystemJdk17/pom.xml"),
+                "<maven.compiler.release>17</maven.compiler.release>"));
+    }
+
+    @Test
+    void insuranceClaimManagementSystemJdk17() throws InterruptedException, IOException {
+        // Build with Maven, EE10 Full profile, jdk17, Payara Micro 6, no MP, ER Diagram = Insurance Claim Management System, include tests, no security
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "insuranceClaimManagementSystemJdk17", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Platform");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Server", "6.2025.5", "6.2025.5");
+        starterPage.setProjectConfiguration("fish.payara.e2e", false, "Java SE 17", "17");
+        starterPage.setMicroProfile("");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("Insurance Claim Management System", true, "domain", true, "service", true, "resource", "HTML", "html");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "insuranceClaimManagementSystemJdk17.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/insuranceClaimManagementSystemJdk17.zip", "./target/test-app-maven/insuranceClaimManagementSystemJdk17");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/insuranceClaimManagementSystemJdk17/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/insuranceClaimManagementSystemJdk17/pom.xml"),
+                "<maven.compiler.release>17</maven.compiler.release>"));
+    }
+
+    @Test
+    void inventorySystemJdk17() throws InterruptedException, IOException {
+        // Build with Maven, EE10 Full profile, jdk17, Payara Micro 6, no MP, ER Diagram = Inventory System, include tests, no security
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "inventorySystemJdk17", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Platform");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Server", "6.2025.5", "6.2025.5");
+        starterPage.setProjectConfiguration("fish.payara.e2e", false, "Java SE 17", "17");
+        starterPage.setMicroProfile("");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("Inventory System", true, "domain", true, "service", true, "resource", "HTML", "html");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "inventorySystemJdk17.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/inventorySystemJdk17.zip", "./target/test-app-maven/inventorySystemJdk17");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/inventorySystemJdk17/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/inventorySystemJdk17/pom.xml"),
+                "<maven.compiler.release>17</maven.compiler.release>"));
+    }
+
+    @Test
+    void laboratoryInformationManagementSystemJdk17() throws InterruptedException, IOException {
+        // Build with Maven, EE10 Full profile, jdk17, Payara Micro 6, no MP, ER Diagram = Laboratory Information Management System, include tests, no security
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "laboratoryInformationManagementSystemJdk17", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Platform");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Server", "6.2025.5", "6.2025.5");
+        starterPage.setProjectConfiguration("fish.payara.e2e", false, "Java SE 17", "17");
+        starterPage.setMicroProfile("");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("Laboratory Information Management System", true, "domain", true, "service", true, "resource", "HTML", "html");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "laboratoryInformationManagementSystemJdk17.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/laboratoryInformationManagementSystemJdk17.zip", "./target/test-app-maven/laboratoryInformationManagementSystemJdk17");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/laboratoryInformationManagementSystemJdk17/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/laboratoryInformationManagementSystemJdk17/pom.xml"),
+                "<maven.compiler.release>17</maven.compiler.release>"));
+    }
+
+    @Test
+    void lawFirmManagementSystemJdk17() throws InterruptedException, IOException {
+        // Build with Maven, EE10 Full profile, jdk17, Payara Micro 6, no MP, ER Diagram = Law Firm Management System, include tests, no security
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "lawFirmManagementSystemJdk17", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Platform");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Server", "6.2025.5", "6.2025.5");
+        starterPage.setProjectConfiguration("fish.payara.e2e", false, "Java SE 17", "17");
+        starterPage.setMicroProfile("");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("Law Firm Management System", true, "domain", true, "service", true, "resource", "HTML", "html");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "lawFirmManagementSystemJdk17.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/lawFirmManagementSystemJdk17.zip", "./target/test-app-maven/lawFirmManagementSystemJdk17");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/lawFirmManagementSystemJdk17/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/lawFirmManagementSystemJdk17/pom.xml"),
+                "<maven.compiler.release>17</maven.compiler.release>"));
+    }
+
+    @Test
+    void legalCaseManagementSystemJdk17() throws InterruptedException, IOException {
+        // Build with Maven, EE10 Full profile, jdk17, Payara Micro 6, no MP, ER Diagram = Legal Case Management System, include tests, no security
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "legalCaseManagementSystemJdk17", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Platform");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Server", "6.2025.5", "6.2025.5");
+        starterPage.setProjectConfiguration("fish.payara.e2e", false, "Java SE 17", "17");
+        starterPage.setMicroProfile("");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("Legal Case Management System", true, "domain", true, "service", true, "resource", "HTML", "html");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "legalCaseManagementSystemJdk17.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/legalCaseManagementSystemJdk17.zip", "./target/test-app-maven/legalCaseManagementSystemJdk17");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/legalCaseManagementSystemJdk17/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/legalCaseManagementSystemJdk17/pom.xml"),
+                "<maven.compiler.release>17</maven.compiler.release>"));
+    }
+
+    @Test
+    void libraryManagementSystemJdk17() throws InterruptedException, IOException {
+        // Build with Maven, EE10 Full profile, jdk17, Payara Micro 6, no MP, ER Diagram = Library Management System, include tests, no security
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "libraryManagementSystemJdk17", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Platform");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Server", "6.2025.5", "6.2025.5");
+        starterPage.setProjectConfiguration("fish.payara.e2e", false, "Java SE 17", "17");
+        starterPage.setMicroProfile("");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("Library Management System", true, "domain", true, "service", true, "resource", "HTML", "html");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "libraryManagementSystemJdk17.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/libraryManagementSystemJdk17.zip", "./target/test-app-maven/libraryManagementSystemJdk17");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/libraryManagementSystemJdk17/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/libraryManagementSystemJdk17/pom.xml"),
+                "<maven.compiler.release>17</maven.compiler.release>"));
+    }
+
+    @Test
+    void membershipManagementSystemJdk17() throws InterruptedException, IOException {
+        // Build with Maven, EE10 Full profile, jdk17, Payara Micro 6, no MP, ER Diagram = Membership Management System, include tests, no security
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "membershipManagementSystemJdk17", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Platform");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Server", "6.2025.5", "6.2025.5");
+        starterPage.setProjectConfiguration("fish.payara.e2e", false, "Java SE 17", "17");
+        starterPage.setMicroProfile("");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("Membership Management System", true, "domain", true, "service", true, "resource", "HTML", "html");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "membershipManagementSystemJdk17.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/membershipManagementSystemJdk17.zip", "./target/test-app-maven/membershipManagementSystemJdk17");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/membershipManagementSystemJdk17/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/membershipManagementSystemJdk17/pom.xml"),
+                "<maven.compiler.release>17</maven.compiler.release>"));
+    }
+
+    @Test
+    void musicStreamingPlatformJdk17() throws InterruptedException, IOException {
+        // Build with Maven, EE10 Full profile, jdk17, Payara Micro 6, no MP, ER Diagram = Music Streaming Platform, include tests, no security
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "musicStreamingPlatformJdk17", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Platform");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Server", "6.2025.5", "6.2025.5");
+        starterPage.setProjectConfiguration("fish.payara.e2e", false, "Java SE 17", "17");
+        starterPage.setMicroProfile("");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("Music Streaming Platform", true, "domain", true, "service", true, "resource", "HTML", "html");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "musicStreamingPlatformJdk17.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/musicStreamingPlatformJdk17.zip", "./target/test-app-maven/musicStreamingPlatformJdk17");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/musicStreamingPlatformJdk17/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/musicStreamingPlatformJdk17/pom.xml"),
+                "<maven.compiler.release>17</maven.compiler.release>"));
+    }
+
+    @Test
+    void propertyManagementSystemJdk17() throws InterruptedException, IOException {
+        // Build with Maven, EE10 Full profile, jdk17, Payara Micro 6, no MP, ER Diagram = Property Management System, include tests, no security
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "propertyManagementSystemJdk17", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Platform");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Server", "6.2025.5", "6.2025.5");
+        starterPage.setProjectConfiguration("fish.payara.e2e", false, "Java SE 17", "17");
+        starterPage.setMicroProfile("");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("Property Management System", true, "domain", true, "service", true, "resource", "HTML", "html");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "propertyManagementSystemJdk17.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/propertyManagementSystemJdk17.zip", "./target/test-app-maven/propertyManagementSystemJdk17");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/propertyManagementSystemJdk17/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/propertyManagementSystemJdk17/pom.xml"),
+                "<maven.compiler.release>17</maven.compiler.release>"));
+    }
+
+    @Test
+    void recruitmentManagementSystemJdk17() throws InterruptedException, IOException {
+        // Build with Maven, EE10 Full profile, jdk17, Payara Micro 6, no MP, ER Diagram = Recruitment Management System, include tests, no security
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "recruitmentManagementSystemJdk17", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Platform");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Server", "6.2025.5", "6.2025.5");
+        starterPage.setProjectConfiguration("fish.payara.e2e", false, "Java SE 17", "17");
+        starterPage.setMicroProfile("");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("Recruitment Management System", true, "domain", true, "service", true, "resource", "HTML", "html");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "recruitmentManagementSystemJdk17.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/recruitmentManagementSystemJdk17.zip", "./target/test-app-maven/recruitmentManagementSystemJdk17");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/recruitmentManagementSystemJdk17/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/recruitmentManagementSystemJdk17/pom.xml"),
+                "<maven.compiler.release>17</maven.compiler.release>"));
+    }
+
+    @Test
+    void salesTrackingJdk17() throws InterruptedException, IOException {
+        // Build with Maven, EE10 Full profile, jdk17, Payara Micro 6, no MP, ER Diagram = Sales Tracking, include tests, no security
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "salesTrackingJdk17", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Platform");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Server", "6.2025.5", "6.2025.5");
+        starterPage.setProjectConfiguration("fish.payara.e2e", false, "Java SE 17", "17");
+        starterPage.setMicroProfile("");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("Sales Tracking", true, "domain", true, "service", true, "resource", "HTML", "html");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "salesTrackingJdk17.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/salesTrackingJdk17.zip", "./target/test-app-maven/salesTrackingJdk17");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/salesTrackingJdk17/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/salesTrackingJdk17/pom.xml"),
+                "<maven.compiler.release>17</maven.compiler.release>"));
     }
 
 }

--- a/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/FullStackAppIT.java
+++ b/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/FullStackAppIT.java
@@ -95,7 +95,7 @@ public class FullStackAppIT {
         starterPage.setProjectConfiguration("fish.payara.e2e", true, "Java SE 11", "11");
         starterPage.setMicroProfile("MicroProfile Metrics");
         starterPage.setDeployment(false, false);
-        starterPage.setERDiagram("Inventory System", true, "domain", false, "service", false, "resource", "HTML", "html");
+        starterPage.setERDiagram("Inventory System", true, "domain", true, "service", true, "resource", "HTML", "html");
         starterPage.openERDiagramPreview();
         starterPage.checkDiagramCodeContains("PRODUCT ||--o{ INVENTORY : contains");
         starterPage.checkDiagramGraphContains("INVENTORY");
@@ -109,43 +109,4 @@ public class FullStackAppIT {
                 "<maven.compiler.release>11</maven.compiler.release>"));
     }
 
-    @Test
-    void mavenJdk17ProductCatalog() throws InterruptedException, IOException {
-        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "ProductCatalogJdk17", "1.0-SNAPSHOT");
-        starterPage.setJakartaEE("Jakarta EE 9", "9", "Web Profile");
-        starterPage.closeGuidePopup();
-        starterPage.setPayaraPlatform("Payara Server", "6.2025.1", "6.2025.1");
-        starterPage.setProjectConfiguration("fish.payara.e2e", true, "Java SE 17", "17");
-        starterPage.setMicroProfile("MicroProfile Metrics");
-        starterPage.setDeployment(false, false);
-        starterPage.setERDiagram("Product Catalog", true, "domain", false, "service", false, "resource", "HTML", "html");
-        starterPage.setSecurity("None");
-        starterPage.generate(page, Paths.get("./target/test-app-maven", "ProductCatalogJdk17.zip"));
-
-        FileManagement.unzip("./target/test-app-maven/ProductCatalogJdk17.zip", "./target/test-app-maven/ProductCatalogJdk17");
-        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/ProductCatalogJdk17/pom.xml")));
-        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/ProductCatalogJdk17/pom.xml"),
-                "<maven.compiler.release>17</maven.compiler.release>"));
-    }
-
-    /*@Test
-    // Disabled - provided gradle wrapper fails to compile with jdk21 - FISH-11064
-    So we need to run the tests with jdk 17
-    void mavenJdk21EnergyManagementSystem() throws InterruptedException, IOException {
-        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "EnergyManagementSystemJdk21", "1.0-SNAPSHOT");
-        starterPage.setJakartaEE("Jakarta EE 10", "10", "Web Profile");
-        starterPage.closeGuidePopup();
-        starterPage.setPayaraPlatform("Payara Server", "6.2024.12", "6.2024.12");
-        starterPage.setProjectConfiguration("fish.payara.e2e", true, "Java SE 21", "21");
-        starterPage.setMicroProfile("MicroProfile Metrics");
-        starterPage.setDeployment(false, false);
-        starterPage.setERDiagram("Energy Management System", false, "domain", false, "service", false, "resource", "HTML", "html");
-        starterPage.setSecurity("None");
-        starterPage.generate(page, Paths.get("./target/test-app-maven", "EnergyManagementSystemJdk21.zip"));
-
-        FileManagement.unzip("./target/test-app-maven/EnergyManagementSystemJdk21.zip", "./target/test-app-maven/EnergyManagementSystemJdk21");
-        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/EnergyManagementSystemJdk21/pom.xml")));
-        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/EnergyManagementSystemJdk21/pom.xml"),
-                "<maven.compiler.release>21</maven.compiler.release>"));
-    }*/
 }

--- a/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/FullStackAppIT.java
+++ b/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/FullStackAppIT.java
@@ -1,0 +1,151 @@
+/*
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.starter.test.e2e.specs;
+
+import com.microsoft.playwright.*;
+import com.microsoft.playwright.junit.UsePlaywright;
+import fish.payara.starter.test.e2e.pages.*;
+import fish.payara.starter.test.e2e.utils.FileManagement;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@UsePlaywright
+public class FullStackAppIT {
+
+    // Generates full stack applications including tests
+    private static Playwright playwright;
+    private static Browser browser;
+    private static BrowserContext context;
+    private static Page page;
+    private static StarterPageActions starterPage;
+
+    @BeforeAll
+    static void launchBrowser() {
+        playwright = Playwright.create();
+        browser = playwright.chromium().launch(new BrowserType.LaunchOptions().setHeadless(true));
+    }
+
+    @BeforeEach
+    void openPage() {
+        context = browser.newContext();
+        page = context.newPage();
+        page.setDefaultTimeout(90000);
+        page.navigate("http://localhost:8080/payara-starter");
+        page.waitForSelector("div.hero", new Page.WaitForSelectorOptions().setTimeout(120000));
+
+        starterPage = new StarterPageActions(page);
+        starterPage.confirmGdpr();
+    }
+
+    @AfterEach
+    void closePage() {
+        context.close();
+    }
+    
+    @AfterAll
+    static void closeBrowser() {
+        playwright.close();
+    }
+
+    @Test
+    void mavenJdk11InventorySystem() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "InventorySystemTestJdk11", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 8", "8", "Web Profile");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Server", "5.2022.5", "5.2022.5");
+        starterPage.setProjectConfiguration("fish.payara.e2e", true, "Java SE 11", "11");
+        starterPage.setMicroProfile("MicroProfile Metrics");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("Inventory System", true, "domain", false, "service", false, "resource", "HTML", "html");
+        starterPage.openERDiagramPreview();
+        starterPage.checkDiagramCodeContains("PRODUCT ||--o{ INVENTORY : contains");
+        starterPage.checkDiagramGraphContains("INVENTORY");
+        starterPage.closeERDiagramPreview();
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "InventorySystemTestJdk11.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/InventorySystemTestJdk11.zip", "./target/test-app-maven/InventorySystemTestJdk11");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/InventorySystemTestJdk11/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/InventorySystemTestJdk11/pom.xml"),
+                "<maven.compiler.release>11</maven.compiler.release>"));
+    }
+
+    @Test
+    void mavenJdk17ProductCatalog() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "ProductCatalogJdk17", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 9", "9", "Web Profile");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Server", "6.2025.1", "6.2025.1");
+        starterPage.setProjectConfiguration("fish.payara.e2e", true, "Java SE 17", "17");
+        starterPage.setMicroProfile("MicroProfile Metrics");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("Product Catalog", true, "domain", false, "service", false, "resource", "HTML", "html");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "ProductCatalogJdk17.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/ProductCatalogJdk17.zip", "./target/test-app-maven/ProductCatalogJdk17");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/ProductCatalogJdk17/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/ProductCatalogJdk17/pom.xml"),
+                "<maven.compiler.release>17</maven.compiler.release>"));
+    }
+
+    /*@Test
+    // Disabled - provided gradle wrapper fails to compile with jdk21 - FISH-11064
+    So we need to run the tests with jdk 17
+    void mavenJdk21EnergyManagementSystem() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "EnergyManagementSystemJdk21", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Web Profile");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Server", "6.2024.12", "6.2024.12");
+        starterPage.setProjectConfiguration("fish.payara.e2e", true, "Java SE 21", "21");
+        starterPage.setMicroProfile("MicroProfile Metrics");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("Energy Management System", false, "domain", false, "service", false, "resource", "HTML", "html");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "EnergyManagementSystemJdk21.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/EnergyManagementSystemJdk21.zip", "./target/test-app-maven/EnergyManagementSystemJdk21");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/EnergyManagementSystemJdk21/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/EnergyManagementSystemJdk21/pom.xml"),
+                "<maven.compiler.release>21</maven.compiler.release>"));
+    }*/
+}

--- a/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/GenerationAppIT.java
+++ b/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/GenerationAppIT.java
@@ -95,7 +95,7 @@ public class GenerationAppIT {
         starterPage.setProjectConfiguration("fish.payara.e2e", false, "Java SE 11", "11");
         starterPage.setMicroProfile("Full MP");
         starterPage.setDeployment(true, false);
-        starterPage.setERDiagram("", true, "domain", false, "service", false, "resource", true);
+        starterPage.setERDiagram("", true, "domain", false, "service", false, "resource", "HTML", "html");
         starterPage.setSecurity("Form Authentication - File Realm");
         starterPage.generate(page, Paths.get("./target/test-app-gradle", "HelloWorldJdk11.zip"));
 
@@ -115,7 +115,7 @@ public class GenerationAppIT {
         starterPage.setProjectConfiguration("fish.payara.e2e", false, "Java SE 17", "17");
         starterPage.setMicroProfile("Full MP");
         starterPage.setDeployment(true, false);
-        starterPage.setERDiagram("", true, "domain", false, "service", false, "resource", true);
+        starterPage.setERDiagram("", true, "domain", false, "service", false, "resource", "HTML", "html");
         starterPage.setSecurity("Form Authentication - File Realm");
         starterPage.generate(page, Paths.get("./target/test-app-gradle", "HelloWorldJdk17.zip"));
 
@@ -135,7 +135,7 @@ public class GenerationAppIT {
         starterPage.setProjectConfiguration("fish.payara.e2e", false, "Java SE 21", "21");
         starterPage.setMicroProfile("Full MP");
         starterPage.setDeployment(true, false);
-        starterPage.setERDiagram("", true, "domain", false, "service", false, "resource", true);
+        starterPage.setERDiagram("", true, "domain", false, "service", false, "resource", "HTML", "html");
         starterPage.setSecurity("Form Authentication - File Realm");
         starterPage.generate(page, Paths.get("./target/test-app-gradle", "HelloWorldJdk21.zip"));
 
@@ -154,7 +154,7 @@ public class GenerationAppIT {
         starterPage.setProjectConfiguration("fish.payara.e2e", true, "Java SE 11", "11");
         starterPage.setMicroProfile("MicroProfile Metrics");
         starterPage.setDeployment(false, false);
-        starterPage.setERDiagram("Inventory System", true, "domain", false, "service", false, "resource", true);
+        starterPage.setERDiagram("Inventory System", true, "domain", false, "service", false, "resource", "HTML", "html");
         starterPage.openERDiagramPreview();
         starterPage.checkDiagramCodeContains("PRODUCT ||--o{ INVENTORY : contains");
         starterPage.checkDiagramGraphContains("INVENTORY");
@@ -177,7 +177,7 @@ public class GenerationAppIT {
         starterPage.setProjectConfiguration("fish.payara.e2e", true, "Java SE 17", "17");
         starterPage.setMicroProfile("MicroProfile Metrics");
         starterPage.setDeployment(false, false);
-        starterPage.setERDiagram("Product Catalog", true, "domain", false, "service", false, "resource", true);
+        starterPage.setERDiagram("Product Catalog", true, "domain", false, "service", false, "resource", "HTML", "html");
         starterPage.setSecurity("None");
         starterPage.generate(page, Paths.get("./target/test-app-maven", "ProductCatalogJdk17.zip"));
 
@@ -198,7 +198,7 @@ public class GenerationAppIT {
         starterPage.setProjectConfiguration("fish.payara.e2e", true, "Java SE 21", "21");
         starterPage.setMicroProfile("MicroProfile Metrics");
         starterPage.setDeployment(false, false);
-        starterPage.setERDiagram("Energy Management System", false, "domain", false, "service", false, "resource", true);
+        starterPage.setERDiagram("Energy Management System", false, "domain", false, "service", false, "resource", "HTML", "html");
         starterPage.setSecurity("None");
         starterPage.generate(page, Paths.get("./target/test-app-maven", "EnergyManagementSystemJdk21.zip"));
 

--- a/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/GradleBuildIT.java
+++ b/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/GradleBuildIT.java
@@ -69,7 +69,7 @@ public class GradleBuildIT {
         context = browser.newContext();
         page = context.newPage();
         page.setDefaultTimeout(90000);
-        page.navigate("http://localhost:8080/payara-starter");
+        page.navigate("http://localhost:8082/payara-starter");
         page.waitForSelector("div.hero", new Page.WaitForSelectorOptions().setTimeout(120000));
 
         starterPage = new StarterPageActions(page);

--- a/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/GradleBuildIT.java
+++ b/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/GradleBuildIT.java
@@ -1,0 +1,149 @@
+/*
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.starter.test.e2e.specs;
+
+import com.microsoft.playwright.*;
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+import com.microsoft.playwright.junit.UsePlaywright;
+import fish.payara.starter.test.e2e.pages.*;
+import fish.payara.starter.test.e2e.utils.FileManagement;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@UsePlaywright
+public class GradleBuildIT {
+
+    // Generates a simple application using Gradle and permuting the jdk used
+    private static Playwright playwright;
+    private static Browser browser;
+    private static BrowserContext context;
+    private static Page page;
+    private static StarterPageActions starterPage;
+
+    @BeforeAll
+    static void launchBrowser() {
+        playwright = Playwright.create();
+        browser = playwright.chromium().launch(new BrowserType.LaunchOptions().setHeadless(true));
+    }
+
+    @BeforeEach
+    void openPage() {
+        context = browser.newContext();
+        page = context.newPage();
+        page.setDefaultTimeout(90000);
+        page.navigate("http://localhost:8080/payara-starter");
+        page.waitForSelector("div.hero", new Page.WaitForSelectorOptions().setTimeout(120000));
+
+        starterPage = new StarterPageActions(page);
+        starterPage.confirmGdpr();
+    }
+
+    @AfterEach
+    void closePage() {
+        context.close();
+    }
+    
+    @AfterAll
+    static void closeBrowser() {
+        playwright.close();
+    }
+
+    @Test
+    void gradleJdk11HelloWorld() throws InterruptedException, IOException {
+        assertThat(page).hasTitle("Generate Payara Application");
+        starterPage.setProjectDescription("Gradle", "fish.payara.playwright.test", "HelloWorldJdk11", "1.0");
+        starterPage.setJakartaEE("Jakarta EE 8", "8", "Web Profile");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Micro", "5.2022.5", "5.2022.5");
+        starterPage.setProjectConfiguration("fish.payara.e2e", false, "Java SE 11", "11");
+        starterPage.setMicroProfile("Full MP");
+        starterPage.setDeployment(true, false);
+        starterPage.setERDiagram("", true, "domain", false, "service", false, "resource", "HTML", "html");
+        starterPage.setSecurity("Form Authentication - File Realm");
+        starterPage.generate(page, Paths.get("./target/test-app-gradle", "HelloWorldJdk11.zip"));
+
+        FileManagement.unzip("./target/test-app-gradle/HelloWorldJdk11.zip", "./target/test-app-gradle/HelloWorldJdk11");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-gradle/HelloWorldJdk11/build.gradle")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-gradle/HelloWorldJdk11/build.gradle"),
+                "sourceCompatibility = JavaVersion.VERSION_11"));
+    }
+    
+    @Test
+    void gradleJdk17HelloWorld() throws InterruptedException, IOException {
+        assertThat(page).hasTitle("Generate Payara Application");
+        starterPage.setProjectDescription("Gradle", "fish.payara.playwright.test", "HelloWorldJdk17", "1.7");
+        starterPage.setJakartaEE("Jakarta EE 9.1", "9.1", "Web Profile");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Micro", "6.2025.1", "6.2025.1");
+        starterPage.setProjectConfiguration("fish.payara.e2e", false, "Java SE 17", "17");
+        starterPage.setMicroProfile("Full MP");
+        starterPage.setDeployment(true, false);
+        starterPage.setERDiagram("", true, "domain", false, "service", false, "resource", "HTML", "html");
+        starterPage.setSecurity("Form Authentication - File Realm");
+        starterPage.generate(page, Paths.get("./target/test-app-gradle", "HelloWorldJdk17.zip"));
+
+        FileManagement.unzip("./target/test-app-gradle/HelloWorldJdk17.zip", "./target/test-app-gradle/HelloWorldJdk17");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-gradle/HelloWorldJdk17/build.gradle")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-gradle/HelloWorldJdk17/build.gradle"),
+                "sourceCompatibility = JavaVersion.VERSION_17"));
+    }
+
+    /*@Test
+    // Disabled - provided gradle wrapper fails to compile with jdk21 - FISH-11064"
+    void gradleJdk21HelloWorld() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Gradle", "fish.payara.playwright.test", "HelloWorldJdk21", "2.0");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Web Profile");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Micro", "6.2025.1", "6.2025.1");
+        starterPage.setProjectConfiguration("fish.payara.e2e", false, "Java SE 21", "21");
+        starterPage.setMicroProfile("Full MP");
+        starterPage.setDeployment(true, false);
+        starterPage.setERDiagram("", true, "domain", false, "service", false, "resource", "HTML", "html");
+        starterPage.setSecurity("Form Authentication - File Realm");
+        starterPage.generate(page, Paths.get("./target/test-app-gradle", "HelloWorldJdk21.zip"));
+
+        FileManagement.unzip("./target/test-app-gradle/HelloWorldJdk21.zip", "./target/test-app-gradle/HelloWorldJdk21");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-gradle/HelloWorldJdk21/build.gradle")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-gradle/HelloWorldJdk21/build.gradle"),
+                "sourceCompatibility = JavaVersion.VERSION_21"));
+    }*/
+}

--- a/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/GradleBuildIT.java
+++ b/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/GradleBuildIT.java
@@ -39,7 +39,6 @@
 package fish.payara.starter.test.e2e.specs;
 
 import com.microsoft.playwright.*;
-import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
 import com.microsoft.playwright.junit.UsePlaywright;
 import fish.payara.starter.test.e2e.pages.*;
 import fish.payara.starter.test.e2e.utils.FileManagement;
@@ -88,62 +87,60 @@ public class GradleBuildIT {
     }
 
     @Test
-    void gradleJdk11HelloWorld() throws InterruptedException, IOException {
-        assertThat(page).hasTitle("Generate Payara Application");
-        starterPage.setProjectDescription("Gradle", "fish.payara.playwright.test", "HelloWorldJdk11", "1.0");
-        starterPage.setJakartaEE("Jakarta EE 8", "8", "Web Profile");
+    void gradleJdk11() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Gradle", "fish.payara.playwright.test", "gradleJdk11", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 8", "8", "Platform");
+        starterPage.setPayaraPlatform("Payara Server", "5.2022.5", "5.2022.5");
         starterPage.closeGuidePopup();
-        starterPage.setPayaraPlatform("Payara Micro", "5.2022.5", "5.2022.5");
-        starterPage.setProjectConfiguration("fish.payara.e2e", false, "Java SE 11", "11");
-        starterPage.setMicroProfile("Full MP");
-        starterPage.setDeployment(true, false);
-        starterPage.setERDiagram("", true, "domain", false, "service", false, "resource", "HTML", "html");
-        starterPage.setSecurity("Form Authentication - File Realm");
-        starterPage.generate(page, Paths.get("./target/test-app-gradle", "HelloWorldJdk11.zip"));
+        starterPage.setProjectConfiguration("fish.payara.test", false, "Java SE 11", "11");
+        starterPage.setMicroProfile("");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("", false, "domain", false, "service", false, "resource", "None", "none");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-gradle", "gradleJdk11.zip"));
 
-        FileManagement.unzip("./target/test-app-gradle/HelloWorldJdk11.zip", "./target/test-app-gradle/HelloWorldJdk11");
-        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-gradle/HelloWorldJdk11/build.gradle")));
-        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-gradle/HelloWorldJdk11/build.gradle"),
+        FileManagement.unzip("./target/test-app-gradle/gradleJdk11.zip", "./target/test-app-gradle/gradleJdk11");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-gradle/gradleJdk11/build.gradle")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-gradle/gradleJdk11/build.gradle"),
                 "sourceCompatibility = JavaVersion.VERSION_11"));
     }
     
     @Test
-    void gradleJdk17HelloWorld() throws InterruptedException, IOException {
-        assertThat(page).hasTitle("Generate Payara Application");
-        starterPage.setProjectDescription("Gradle", "fish.payara.playwright.test", "HelloWorldJdk17", "1.7");
+    void gradleJdk17() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Gradle", "fish.payara.playwright.test", "gradleJdk17", "1.0-SNAPSHOT");
         starterPage.setJakartaEE("Jakarta EE 9.1", "9.1", "Web Profile");
         starterPage.closeGuidePopup();
-        starterPage.setPayaraPlatform("Payara Micro", "6.2025.1", "6.2025.1");
+        starterPage.setPayaraPlatform("Payara Server", "6.2025.1", "6.2025.1");
         starterPage.setProjectConfiguration("fish.payara.e2e", false, "Java SE 17", "17");
-        starterPage.setMicroProfile("Full MP");
-        starterPage.setDeployment(true, false);
-        starterPage.setERDiagram("", true, "domain", false, "service", false, "resource", "HTML", "html");
-        starterPage.setSecurity("Form Authentication - File Realm");
-        starterPage.generate(page, Paths.get("./target/test-app-gradle", "HelloWorldJdk17.zip"));
+        starterPage.setMicroProfile("");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("", false, "domain", false, "service", false, "resource", "None", "none");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-gradle", "gradleJdk17.zip"));
 
-        FileManagement.unzip("./target/test-app-gradle/HelloWorldJdk17.zip", "./target/test-app-gradle/HelloWorldJdk17");
-        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-gradle/HelloWorldJdk17/build.gradle")));
-        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-gradle/HelloWorldJdk17/build.gradle"),
+        FileManagement.unzip("./target/test-app-gradle/gradleJdk17.zip", "./target/test-app-gradle/gradleJdk17");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-gradle/gradleJdk17/build.gradle")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-gradle/gradleJdk17/build.gradle"),
                 "sourceCompatibility = JavaVersion.VERSION_17"));
     }
 
     /*@Test
     // Disabled - provided gradle wrapper fails to compile with jdk21 - FISH-11064"
-    void gradleJdk21HelloWorld() throws InterruptedException, IOException {
-        starterPage.setProjectDescription("Gradle", "fish.payara.playwright.test", "HelloWorldJdk21", "2.0");
+    void gradleJdk21() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Gradle", "fish.payara.playwright.test", "gradleJdk21", "2.0");
         starterPage.setJakartaEE("Jakarta EE 10", "10", "Web Profile");
         starterPage.closeGuidePopup();
         starterPage.setPayaraPlatform("Payara Micro", "6.2025.1", "6.2025.1");
         starterPage.setProjectConfiguration("fish.payara.e2e", false, "Java SE 21", "21");
-        starterPage.setMicroProfile("Full MP");
-        starterPage.setDeployment(true, false);
-        starterPage.setERDiagram("", true, "domain", false, "service", false, "resource", "HTML", "html");
-        starterPage.setSecurity("Form Authentication - File Realm");
-        starterPage.generate(page, Paths.get("./target/test-app-gradle", "HelloWorldJdk21.zip"));
+        starterPage.setMicroProfile("");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("", false, "domain", false, "service", false, "resource", "None", "none");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-gradle", "gradleJdk21.zip"));
 
-        FileManagement.unzip("./target/test-app-gradle/HelloWorldJdk21.zip", "./target/test-app-gradle/HelloWorldJdk21");
-        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-gradle/HelloWorldJdk21/build.gradle")));
-        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-gradle/HelloWorldJdk21/build.gradle"),
+        FileManagement.unzip("./target/test-app-gradle/gradleJdk21.zip", "./target/test-app-gradle/gradleJdk21");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-gradle/gradleJdk21/build.gradle")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-gradle/gradleJdk21/build.gradle"),
                 "sourceCompatibility = JavaVersion.VERSION_21"));
     }*/
 }

--- a/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/MicroProfileOptionsIT.java
+++ b/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/MicroProfileOptionsIT.java
@@ -87,65 +87,79 @@ public class MicroProfileOptionsIT {
     }
 
     @Test
-    void mavenJdk11InventorySystem() throws InterruptedException, IOException {
-        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "InventorySystemTestJdk11", "1.0-SNAPSHOT");
-        starterPage.setJakartaEE("Jakarta EE 8", "8", "Web Profile");
-        starterPage.closeGuidePopup();
-        starterPage.setPayaraPlatform("Payara Server", "5.2022.5", "5.2022.5");
-        starterPage.setProjectConfiguration("fish.payara.e2e", true, "Java SE 11", "11");
-        starterPage.setMicroProfile("MicroProfile Metrics");
-        starterPage.setDeployment(false, false);
-        starterPage.setERDiagram("Inventory System", true, "domain", false, "service", false, "resource", "HTML", "html");
-        starterPage.openERDiagramPreview();
-        starterPage.checkDiagramCodeContains("PRODUCT ||--o{ INVENTORY : contains");
-        starterPage.checkDiagramGraphContains("INVENTORY");
-        starterPage.closeERDiagramPreview();
-        starterPage.setSecurity("None");
-        starterPage.generate(page, Paths.get("./target/test-app-maven", "InventorySystemTestJdk11.zip"));
-
-        FileManagement.unzip("./target/test-app-maven/InventorySystemTestJdk11.zip", "./target/test-app-maven/InventorySystemTestJdk11");
-        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/InventorySystemTestJdk11/pom.xml")));
-        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/InventorySystemTestJdk11/pom.xml"),
-                "<maven.compiler.release>11</maven.compiler.release>"));
-    }
-
-    @Test
-    void mavenJdk17ProductCatalog() throws InterruptedException, IOException {
-        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "ProductCatalogJdk17", "1.0-SNAPSHOT");
-        starterPage.setJakartaEE("Jakarta EE 9", "9", "Web Profile");
-        starterPage.closeGuidePopup();
+    void PayaraServer6EE10Jdk17FullMP() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "PayaraServer6EE10Jdk17FullMP", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Platform");
         starterPage.setPayaraPlatform("Payara Server", "6.2025.1", "6.2025.1");
-        starterPage.setProjectConfiguration("fish.payara.e2e", true, "Java SE 17", "17");
-        starterPage.setMicroProfile("MicroProfile Metrics");
+        starterPage.closeGuidePopup();
+        starterPage.setProjectConfiguration("fish.payara.test", false, "Java SE 17", "17");
+        starterPage.setMicroProfile("Full MP");
         starterPage.setDeployment(false, false);
-        starterPage.setERDiagram("Product Catalog", true, "domain", false, "service", false, "resource", "HTML", "html");
+        starterPage.setERDiagram("", false, "domain", false, "service", false, "resource", "None", "none");
         starterPage.setSecurity("None");
-        starterPage.generate(page, Paths.get("./target/test-app-maven", "ProductCatalogJdk17.zip"));
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "PayaraServer6EE10Jdk17FullMP.zip"));
 
-        FileManagement.unzip("./target/test-app-maven/ProductCatalogJdk17.zip", "./target/test-app-maven/ProductCatalogJdk17");
-        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/ProductCatalogJdk17/pom.xml")));
-        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/ProductCatalogJdk17/pom.xml"),
+        FileManagement.unzip("./target/test-app-maven/PayaraServer6EE10Jdk17FullMP.zip", "./target/test-app-maven/PayaraServer6EE10Jdk17FullMP");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/PayaraServer6EE10Jdk17FullMP/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/PayaraServer6EE10Jdk17FullMP/pom.xml"),
                 "<maven.compiler.release>17</maven.compiler.release>"));
     }
 
-    /*@Test
-    // Disabled - provided gradle wrapper fails to compile with jdk21 - FISH-11064
-    So we need to run the tests with jdk 17
-    void mavenJdk21EnergyManagementSystem() throws InterruptedException, IOException {
-        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "EnergyManagementSystemJdk21", "1.0-SNAPSHOT");
-        starterPage.setJakartaEE("Jakarta EE 10", "10", "Web Profile");
+    @Test
+    void PayaraServer6EE10Jdk17MPConfig() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "PayaraServer6EE10Jdk17MPConfig", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Platform");
+        starterPage.setPayaraPlatform("Payara Server", "6.2025.1", "6.2025.1");
         starterPage.closeGuidePopup();
-        starterPage.setPayaraPlatform("Payara Server", "6.2024.12", "6.2024.12");
-        starterPage.setProjectConfiguration("fish.payara.e2e", true, "Java SE 21", "21");
+        starterPage.setProjectConfiguration("fish.payara.test", false, "Java SE 17", "17");
+        starterPage.setMicroProfile("MicroProfile Config");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("", false, "domain", false, "service", false, "resource", "None", "none");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "PayaraServer6EE10Jdk17MPConfig.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/PayaraServer6EE10Jdk17MPConfig.zip", "./target/test-app-maven/PayaraServer6EE10Jdk17MPConfig");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/PayaraServer6EE10Jdk17MPConfig/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/PayaraServer6EE10Jdk17MPConfig/pom.xml"),
+                "<maven.compiler.release>17</maven.compiler.release>"));
+    }
+
+    @Test
+    void PayaraServer6EE10Jdk17MPFault() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "PayaraServer6EE10Jdk17MPFault", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Platform");
+        starterPage.setPayaraPlatform("Payara Server", "6.2025.1", "6.2025.1");
+        starterPage.closeGuidePopup();
+        starterPage.setProjectConfiguration("fish.payara.test", false, "Java SE 17", "17");
+        starterPage.setMicroProfile("MicroProfile Fault Tolerance");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("", false, "domain", false, "service", false, "resource", "None", "none");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "PayaraServer6EE10Jdk17MPFault.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/PayaraServer6EE10Jdk17MPFault.zip", "./target/test-app-maven/PayaraServer6EE10Jdk17MPFault");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/PayaraServer6EE10Jdk17MPFault/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/PayaraServer6EE10Jdk17MPFault/pom.xml"),
+                "<maven.compiler.release>17</maven.compiler.release>"));
+    }
+
+    @Test
+    void PayaraServer6EE10Jdk17MPMetrics() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "PayaraServer6EE10Jdk17MPMetrics", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Platform");
+        starterPage.setPayaraPlatform("Payara Server", "6.2025.1", "6.2025.1");
+        starterPage.closeGuidePopup();
+        starterPage.setProjectConfiguration("fish.payara.test", false, "Java SE 17", "17");
         starterPage.setMicroProfile("MicroProfile Metrics");
         starterPage.setDeployment(false, false);
-        starterPage.setERDiagram("Energy Management System", false, "domain", false, "service", false, "resource", "HTML", "html");
+        starterPage.setERDiagram("", false, "domain", false, "service", false, "resource", "None", "none");
         starterPage.setSecurity("None");
-        starterPage.generate(page, Paths.get("./target/test-app-maven", "EnergyManagementSystemJdk21.zip"));
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "PayaraServer6EE10Jdk17MPMetrics.zip"));
 
-        FileManagement.unzip("./target/test-app-maven/EnergyManagementSystemJdk21.zip", "./target/test-app-maven/EnergyManagementSystemJdk21");
-        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/EnergyManagementSystemJdk21/pom.xml")));
-        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/EnergyManagementSystemJdk21/pom.xml"),
-                "<maven.compiler.release>21</maven.compiler.release>"));
-    }*/
+        FileManagement.unzip("./target/test-app-maven/PayaraServer6EE10Jdk17MPMetrics.zip", "./target/test-app-maven/PayaraServer6EE10Jdk17MPMetrics");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/PayaraServer6EE10Jdk17MPMetrics/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/PayaraServer6EE10Jdk17MPMetrics/pom.xml"),
+                "<maven.compiler.release>17</maven.compiler.release>"));
+    }
+
 }

--- a/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/MicroProfileOptionsIT.java
+++ b/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/MicroProfileOptionsIT.java
@@ -1,0 +1,151 @@
+/*
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.starter.test.e2e.specs;
+
+import com.microsoft.playwright.*;
+import com.microsoft.playwright.junit.UsePlaywright;
+import fish.payara.starter.test.e2e.pages.*;
+import fish.payara.starter.test.e2e.utils.FileManagement;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@UsePlaywright
+public class MicroProfileOptionsIT {
+
+    // Generates a simple application permuting the MicroProfile options Full MP/MP Config/MP Open API/MP Fault Tolerance/MP Metrics
+    private static Playwright playwright;
+    private static Browser browser;
+    private static BrowserContext context;
+    private static Page page;
+    private static StarterPageActions starterPage;
+
+    @BeforeAll
+    static void launchBrowser() {
+        playwright = Playwright.create();
+        browser = playwright.chromium().launch(new BrowserType.LaunchOptions().setHeadless(true));
+    }
+
+    @BeforeEach
+    void openPage() {
+        context = browser.newContext();
+        page = context.newPage();
+        page.setDefaultTimeout(90000);
+        page.navigate("http://localhost:8080/payara-starter");
+        page.waitForSelector("div.hero", new Page.WaitForSelectorOptions().setTimeout(120000));
+
+        starterPage = new StarterPageActions(page);
+        starterPage.confirmGdpr();
+    }
+
+    @AfterEach
+    void closePage() {
+        context.close();
+    }
+    
+    @AfterAll
+    static void closeBrowser() {
+        playwright.close();
+    }
+
+    @Test
+    void mavenJdk11InventorySystem() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "InventorySystemTestJdk11", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 8", "8", "Web Profile");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Server", "5.2022.5", "5.2022.5");
+        starterPage.setProjectConfiguration("fish.payara.e2e", true, "Java SE 11", "11");
+        starterPage.setMicroProfile("MicroProfile Metrics");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("Inventory System", true, "domain", false, "service", false, "resource", "HTML", "html");
+        starterPage.openERDiagramPreview();
+        starterPage.checkDiagramCodeContains("PRODUCT ||--o{ INVENTORY : contains");
+        starterPage.checkDiagramGraphContains("INVENTORY");
+        starterPage.closeERDiagramPreview();
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "InventorySystemTestJdk11.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/InventorySystemTestJdk11.zip", "./target/test-app-maven/InventorySystemTestJdk11");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/InventorySystemTestJdk11/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/InventorySystemTestJdk11/pom.xml"),
+                "<maven.compiler.release>11</maven.compiler.release>"));
+    }
+
+    @Test
+    void mavenJdk17ProductCatalog() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "ProductCatalogJdk17", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 9", "9", "Web Profile");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Server", "6.2025.1", "6.2025.1");
+        starterPage.setProjectConfiguration("fish.payara.e2e", true, "Java SE 17", "17");
+        starterPage.setMicroProfile("MicroProfile Metrics");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("Product Catalog", true, "domain", false, "service", false, "resource", "HTML", "html");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "ProductCatalogJdk17.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/ProductCatalogJdk17.zip", "./target/test-app-maven/ProductCatalogJdk17");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/ProductCatalogJdk17/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/ProductCatalogJdk17/pom.xml"),
+                "<maven.compiler.release>17</maven.compiler.release>"));
+    }
+
+    /*@Test
+    // Disabled - provided gradle wrapper fails to compile with jdk21 - FISH-11064
+    So we need to run the tests with jdk 17
+    void mavenJdk21EnergyManagementSystem() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "EnergyManagementSystemJdk21", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Web Profile");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Server", "6.2024.12", "6.2024.12");
+        starterPage.setProjectConfiguration("fish.payara.e2e", true, "Java SE 21", "21");
+        starterPage.setMicroProfile("MicroProfile Metrics");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("Energy Management System", false, "domain", false, "service", false, "resource", "HTML", "html");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "EnergyManagementSystemJdk21.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/EnergyManagementSystemJdk21.zip", "./target/test-app-maven/EnergyManagementSystemJdk21");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/EnergyManagementSystemJdk21/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/EnergyManagementSystemJdk21/pom.xml"),
+                "<maven.compiler.release>21</maven.compiler.release>"));
+    }*/
+}

--- a/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/MicroProfileOptionsIT.java
+++ b/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/MicroProfileOptionsIT.java
@@ -69,7 +69,7 @@ public class MicroProfileOptionsIT {
         context = browser.newContext();
         page = context.newPage();
         page.setDefaultTimeout(90000);
-        page.navigate("http://localhost:8080/payara-starter");
+        page.navigate("http://localhost:8082/payara-starter");
         page.waitForSelector("div.hero", new Page.WaitForSelectorOptions().setTimeout(120000));
 
         starterPage = new StarterPageActions(page);

--- a/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/PayaraVersionsIT.java
+++ b/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/PayaraVersionsIT.java
@@ -69,7 +69,7 @@ public class PayaraVersionsIT {
         context = browser.newContext();
         page = context.newPage();
         page.setDefaultTimeout(90000);
-        page.navigate("http://localhost:8080/payara-starter");
+        page.navigate("http://localhost:8082/payara-starter");
         page.waitForSelector("div.hero", new Page.WaitForSelectorOptions().setTimeout(120000));
 
         starterPage = new StarterPageActions(page);

--- a/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/PayaraVersionsIT.java
+++ b/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/PayaraVersionsIT.java
@@ -1,0 +1,149 @@
+/*
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.starter.test.e2e.specs;
+
+import com.microsoft.playwright.*;
+import com.microsoft.playwright.junit.UsePlaywright;
+import fish.payara.starter.test.e2e.pages.*;
+import fish.payara.starter.test.e2e.utils.FileManagement;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@UsePlaywright
+public class PayaraVersionsIT {
+
+    // Generates a simple application permuting the version of JDK and Payara used (server/micro)
+    private static Playwright playwright;
+    private static Browser browser;
+    private static BrowserContext context;
+    private static Page page;
+    private static StarterPageActions starterPage;
+
+    @BeforeAll
+    static void launchBrowser() {
+        playwright = Playwright.create();
+        browser = playwright.chromium().launch(new BrowserType.LaunchOptions().setHeadless(true));
+    }
+
+    @BeforeEach
+    void openPage() {
+        context = browser.newContext();
+        page = context.newPage();
+        page.setDefaultTimeout(90000);
+        page.navigate("http://localhost:8080/payara-starter");
+        page.waitForSelector("div.hero", new Page.WaitForSelectorOptions().setTimeout(120000));
+
+        starterPage = new StarterPageActions(page);
+        starterPage.confirmGdpr();
+    }
+
+    @AfterEach
+    void closePage() {
+        context.close();
+    }
+    
+    @AfterAll
+    static void closeBrowser() {
+        playwright.close();
+    }
+
+    @Test
+    void PayaraServer5Jdk8Java11() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "PayaraServer5Jdk8Java11", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 8", "8", "Platform");
+        starterPage.setPayaraPlatform("Payara Server", "5.2022.5", "5.2022.5");
+        starterPage.closeGuidePopup();
+        starterPage.setProjectConfiguration("fish.payara.test", false, "Java SE 11", "11");
+        starterPage.setMicroProfile("None");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("", false, "domain", false, "service", false, "resource", "None", "none");
+        starterPage.closeERDiagramPreview();
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "PayaraServer5Jdk8Java11.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/PayaraServer5Jdk8Java11.zip", "./target/test-app-maven/PayaraServer5Jdk8Java11");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/PayaraServer5Jdk8Java11/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/PayaraServer5Jdk8Java11/pom.xml"),
+                "<maven.compiler.release>11</maven.compiler.release>"));
+    }
+
+    @Test
+    void PayaraServer5Jdk9Java11() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "PayaraServer5Jdk8Java11", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 9", "9", "Platform");
+        starterPage.setPayaraPlatform("Payara Server", "6.2025.1", "6.2025.1");
+        starterPage.closeGuidePopup();
+        starterPage.setProjectConfiguration("fish.payara.test", false, "Java SE 11", "11");
+        starterPage.setMicroProfile("None");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("", false, "domain", false, "service", false, "resource", "None", "none");
+        starterPage.closeERDiagramPreview();
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "PayaraServer5Jdk8Java11.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/PayaraServer5Jdk8Java11.zip", "./target/test-app-maven/PayaraServer5Jdk8Java11");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/PayaraServer5Jdk8Java11/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/PayaraServer5Jdk8Java11/pom.xml"),
+                "<maven.compiler.release>11</maven.compiler.release>"));
+    }
+
+    /*@Test
+    // Disabled - provided gradle wrapper fails to compile with jdk21 - FISH-11064
+    So we need to run the tests with jdk 17
+    void mavenJdk21EnergyManagementSystem() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "EnergyManagementSystemJdk21", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Web Profile");
+        starterPage.closeGuidePopup();
+        starterPage.setPayaraPlatform("Payara Server", "6.2024.12", "6.2024.12");
+        starterPage.setProjectConfiguration("fish.payara.e2e", true, "Java SE 21", "21");
+        starterPage.setMicroProfile("MicroProfile Metrics");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("Energy Management System", false, "domain", false, "service", false, "resource", "HTML", "html");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "EnergyManagementSystemJdk21.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/EnergyManagementSystemJdk21.zip", "./target/test-app-maven/EnergyManagementSystemJdk21");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/EnergyManagementSystemJdk21/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/EnergyManagementSystemJdk21/pom.xml"),
+                "<maven.compiler.release>21</maven.compiler.release>"));
+    }*/
+}

--- a/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/PayaraVersionsIT.java
+++ b/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/PayaraVersionsIT.java
@@ -87,63 +87,156 @@ public class PayaraVersionsIT {
     }
 
     @Test
-    void PayaraServer5Jdk8Java11() throws InterruptedException, IOException {
-        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "PayaraServer5Jdk8Java11", "1.0-SNAPSHOT");
+    void PayaraServer5EE8Jdk11() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "PayaraServer5EE8Jdk11", "1.0-SNAPSHOT");
         starterPage.setJakartaEE("Jakarta EE 8", "8", "Platform");
         starterPage.setPayaraPlatform("Payara Server", "5.2022.5", "5.2022.5");
         starterPage.closeGuidePopup();
         starterPage.setProjectConfiguration("fish.payara.test", false, "Java SE 11", "11");
-        starterPage.setMicroProfile("None");
+        starterPage.setMicroProfile("");
         starterPage.setDeployment(false, false);
         starterPage.setERDiagram("", false, "domain", false, "service", false, "resource", "None", "none");
-        starterPage.closeERDiagramPreview();
         starterPage.setSecurity("None");
-        starterPage.generate(page, Paths.get("./target/test-app-maven", "PayaraServer5Jdk8Java11.zip"));
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "PayaraServer5EE8Jdk11.zip"));
 
-        FileManagement.unzip("./target/test-app-maven/PayaraServer5Jdk8Java11.zip", "./target/test-app-maven/PayaraServer5Jdk8Java11");
-        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/PayaraServer5Jdk8Java11/pom.xml")));
-        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/PayaraServer5Jdk8Java11/pom.xml"),
+        FileManagement.unzip("./target/test-app-maven/PayaraServer5EE8Jdk11.zip", "./target/test-app-maven/PayaraServer5EE8Jdk11");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/PayaraServer5EE8Jdk11/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/PayaraServer5EE8Jdk11/pom.xml"),
                 "<maven.compiler.release>11</maven.compiler.release>"));
     }
 
     @Test
-    void PayaraServer5Jdk9Java11() throws InterruptedException, IOException {
-        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "PayaraServer5Jdk8Java11", "1.0-SNAPSHOT");
+    void PayaraServer6EE9Jdk11() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "PayaraServer6EE9Jdk11", "1.0-SNAPSHOT");
         starterPage.setJakartaEE("Jakarta EE 9", "9", "Platform");
         starterPage.setPayaraPlatform("Payara Server", "6.2025.1", "6.2025.1");
         starterPage.closeGuidePopup();
         starterPage.setProjectConfiguration("fish.payara.test", false, "Java SE 11", "11");
-        starterPage.setMicroProfile("None");
+        starterPage.setMicroProfile("");
         starterPage.setDeployment(false, false);
         starterPage.setERDiagram("", false, "domain", false, "service", false, "resource", "None", "none");
-        starterPage.closeERDiagramPreview();
         starterPage.setSecurity("None");
-        starterPage.generate(page, Paths.get("./target/test-app-maven", "PayaraServer5Jdk8Java11.zip"));
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "PayaraServer6EE9Jdk11.zip"));
 
-        FileManagement.unzip("./target/test-app-maven/PayaraServer5Jdk8Java11.zip", "./target/test-app-maven/PayaraServer5Jdk8Java11");
-        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/PayaraServer5Jdk8Java11/pom.xml")));
-        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/PayaraServer5Jdk8Java11/pom.xml"),
+        FileManagement.unzip("./target/test-app-maven/PayaraServer6EE9Jdk11.zip", "./target/test-app-maven/PayaraServer6EE9Jdk11");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/PayaraServer6EE9Jdk11/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/PayaraServer6EE9Jdk11/pom.xml"),
                 "<maven.compiler.release>11</maven.compiler.release>"));
+    }
+
+    @Test
+    void PayaraServer6EE91Jdk11() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "PayaraServer6EE91Jdk11", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 9.1", "9.1", "Platform");
+        starterPage.setPayaraPlatform("Payara Server", "6.2025.1", "6.2025.1");
+        starterPage.closeGuidePopup();
+        starterPage.setProjectConfiguration("fish.payara.test", false, "Java SE 11", "11");
+        starterPage.setMicroProfile("");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("", false, "domain", false, "service", false, "resource", "None", "none");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "PayaraServer6EE91Jdk11.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/PayaraServer6EE91Jdk11.zip", "./target/test-app-maven/PayaraServer6EE91Jdk11");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/PayaraServer6EE91Jdk11/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/PayaraServer6EE91Jdk11/pom.xml"),
+                "<maven.compiler.release>11</maven.compiler.release>"));
+    }
+
+    @Test
+    void PayaraServer6EE10Jdk17() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "PayaraServer6EE10Jdk17", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Platform");
+        starterPage.setPayaraPlatform("Payara Server", "6.2025.1", "6.2025.1");
+        starterPage.closeGuidePopup();
+        starterPage.setProjectConfiguration("fish.payara.test", false, "Java SE 17", "17");
+        starterPage.setMicroProfile("");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("", false, "domain", false, "service", false, "resource", "None", "none");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "PayaraServer6EE10Jdk17.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/PayaraServer6EE10Jdk17.zip", "./target/test-app-maven/PayaraServer6EE10Jdk17");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/PayaraServer6EE10Jdk17/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/PayaraServer6EE10Jdk17/pom.xml"),
+                "<maven.compiler.release>17</maven.compiler.release>"));
+    }
+
+    @Test
+    void PayaraMicro6EE10Jdk17() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "PayaraMicro6EE10Jdk17", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Platform");
+        starterPage.setPayaraPlatform("Payara Micro", "6.2025.1", "6.2025.1");
+        starterPage.closeGuidePopup();
+        starterPage.setProjectConfiguration("fish.payara.test", false, "Java SE 17", "17");
+        starterPage.setMicroProfile("");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("", false, "domain", false, "service", false, "resource", "None", "none");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "PayaraMicro6EE10Jdk17.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/PayaraMicro6EE10Jdk17.zip", "./target/test-app-maven/PayaraMicro6EE10Jdk17");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/PayaraMicro6EE10Jdk17/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/PayaraMicro6EE10Jdk17/pom.xml"),
+                "<maven.compiler.release>17</maven.compiler.release>"));
+    }
+
+    @Test
+    void PayaraServerWeb6EE10Jdk17() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "PayaraServerWeb6EE10Jdk17", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Web Profile");
+        starterPage.setPayaraPlatform("Payara Server", "6.2025.1", "6.2025.1");
+        starterPage.closeGuidePopup();
+        starterPage.setProjectConfiguration("fish.payara.test", false, "Java SE 17", "17");
+        starterPage.setMicroProfile("");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("", false, "domain", false, "service", false, "resource", "None", "none");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "PayaraServerWeb6EE10Jdk17.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/PayaraServerWeb6EE10Jdk17.zip", "./target/test-app-maven/PayaraServerWeb6EE10Jdk17");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/PayaraServerWeb6EE10Jdk17/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/PayaraServerWeb6EE10Jdk17/pom.xml"),
+                "<maven.compiler.release>17</maven.compiler.release>"));
+    }
+
+    @Test
+    void PayaraServerCore6EE10Jdk17() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "PayaraServerCore6EE10Jdk17", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Core Profile");
+        starterPage.setPayaraPlatform("Payara Server", "6.2025.1", "6.2025.1");
+        starterPage.closeGuidePopup();
+        starterPage.setProjectConfiguration("fish.payara.test", false, "Java SE 17", "17");
+        starterPage.setMicroProfile("");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("", false, "domain", false, "service", false, "resource", "None", "none");
+        starterPage.setSecurity("None");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "PayaraServerCore6EE10Jdk17.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/PayaraServerCore6EE10Jdk17.zip", "./target/test-app-maven/PayaraServerCore6EE10Jdk17");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/PayaraServerCore6EE10Jdk17/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/PayaraServerCore6EE10Jdk17/pom.xml"),
+                "<maven.compiler.release>17</maven.compiler.release>"));
     }
 
     /*@Test
     // Disabled - provided gradle wrapper fails to compile with jdk21 - FISH-11064
     So we need to run the tests with jdk 17
-    void mavenJdk21EnergyManagementSystem() throws InterruptedException, IOException {
-        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "EnergyManagementSystemJdk21", "1.0-SNAPSHOT");
-        starterPage.setJakartaEE("Jakarta EE 10", "10", "Web Profile");
+    void PayaraMicro6EE10Jdk21() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "PayaraMicro6EE10Jdk21", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Platform");
+        starterPage.setPayaraPlatform("Payara Micro", "6.2025.1", "6.2025.1");
         starterPage.closeGuidePopup();
-        starterPage.setPayaraPlatform("Payara Server", "6.2024.12", "6.2024.12");
-        starterPage.setProjectConfiguration("fish.payara.e2e", true, "Java SE 21", "21");
-        starterPage.setMicroProfile("MicroProfile Metrics");
+        starterPage.setProjectConfiguration("fish.payara.test", false, "Java SE 21", "21");
+        starterPage.setMicroProfile("");
         starterPage.setDeployment(false, false);
-        starterPage.setERDiagram("Energy Management System", false, "domain", false, "service", false, "resource", "HTML", "html");
+        starterPage.setERDiagram("", false, "domain", false, "service", false, "resource", "None", "none");
         starterPage.setSecurity("None");
-        starterPage.generate(page, Paths.get("./target/test-app-maven", "EnergyManagementSystemJdk21.zip"));
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "PayaraMicro6EE10Jdk17.zip"));
 
-        FileManagement.unzip("./target/test-app-maven/EnergyManagementSystemJdk21.zip", "./target/test-app-maven/EnergyManagementSystemJdk21");
-        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/EnergyManagementSystemJdk21/pom.xml")));
-        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/EnergyManagementSystemJdk21/pom.xml"),
-                "<maven.compiler.release>21</maven.compiler.release>"));
+       FileManagement.unzip("./target/test-app-maven/PayaraMicro6EE10Jdk21.zip", "./target/test-app-maven/PayaraMicro6EE10Jdk21");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/PayaraMicro6EE10Jdk21/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/PayaraMicro6EE10Jdk21/pom.xml"),
+                "<maven.compiler.release>17</maven.compiler.release>"));
     }*/
 }

--- a/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/SecurityOptionsIT.java
+++ b/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/SecurityOptionsIT.java
@@ -39,7 +39,6 @@
 package fish.payara.starter.test.e2e.specs;
 
 import com.microsoft.playwright.*;
-import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
 import com.microsoft.playwright.junit.UsePlaywright;
 import fish.payara.starter.test.e2e.pages.*;
 import fish.payara.starter.test.e2e.utils.FileManagement;
@@ -50,7 +49,9 @@ import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @UsePlaywright
-public class GenerationAppIT {
+public class SecurityOptionsIT {
+
+    // Generates applications with different security options
     private static Playwright playwright;
     private static Browser browser;
     private static BrowserContext context;
@@ -84,66 +85,6 @@ public class GenerationAppIT {
     static void closeBrowser() {
         playwright.close();
     }
-
-    @Test
-    void gradleJdk11HelloWorld() throws InterruptedException, IOException {
-        assertThat(page).hasTitle("Generate Payara Application");
-        starterPage.setProjectDescription("Gradle", "fish.payara.playwright.test", "HelloWorldJdk11", "1.0");
-        starterPage.setJakartaEE("Jakarta EE 8", "8", "Web Profile");
-        starterPage.closeGuidePopup();
-        starterPage.setPayaraPlatform("Payara Micro", "5.2022.5", "5.2022.5");
-        starterPage.setProjectConfiguration("fish.payara.e2e", false, "Java SE 11", "11");
-        starterPage.setMicroProfile("Full MP");
-        starterPage.setDeployment(true, false);
-        starterPage.setERDiagram("", true, "domain", false, "service", false, "resource", "HTML", "html");
-        starterPage.setSecurity("Form Authentication - File Realm");
-        starterPage.generate(page, Paths.get("./target/test-app-gradle", "HelloWorldJdk11.zip"));
-
-        FileManagement.unzip("./target/test-app-gradle/HelloWorldJdk11.zip", "./target/test-app-gradle/HelloWorldJdk11");
-        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-gradle/HelloWorldJdk11/build.gradle")));
-        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-gradle/HelloWorldJdk11/build.gradle"),
-                "sourceCompatibility = JavaVersion.VERSION_11"));
-    }
-    
-    @Test
-    void gradleJdk17HelloWorld() throws InterruptedException, IOException {
-        assertThat(page).hasTitle("Generate Payara Application");
-        starterPage.setProjectDescription("Gradle", "fish.payara.playwright.test", "HelloWorldJdk17", "1.7");
-        starterPage.setJakartaEE("Jakarta EE 9.1", "9.1", "Web Profile");
-        starterPage.closeGuidePopup();
-        starterPage.setPayaraPlatform("Payara Micro", "6.2025.1", "6.2025.1");
-        starterPage.setProjectConfiguration("fish.payara.e2e", false, "Java SE 17", "17");
-        starterPage.setMicroProfile("Full MP");
-        starterPage.setDeployment(true, false);
-        starterPage.setERDiagram("", true, "domain", false, "service", false, "resource", "HTML", "html");
-        starterPage.setSecurity("Form Authentication - File Realm");
-        starterPage.generate(page, Paths.get("./target/test-app-gradle", "HelloWorldJdk17.zip"));
-
-        FileManagement.unzip("./target/test-app-gradle/HelloWorldJdk17.zip", "./target/test-app-gradle/HelloWorldJdk17");
-        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-gradle/HelloWorldJdk17/build.gradle")));
-        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-gradle/HelloWorldJdk17/build.gradle"),
-                "sourceCompatibility = JavaVersion.VERSION_17"));
-    }
-
-    /*@Test
-    // Disabled - provided gradle wrapper fails to compile with jdk21 - FISH-11064"
-    void gradleJdk21HelloWorld() throws InterruptedException, IOException {
-        starterPage.setProjectDescription("Gradle", "fish.payara.playwright.test", "HelloWorldJdk21", "2.0");
-        starterPage.setJakartaEE("Jakarta EE 10", "10", "Web Profile");
-        starterPage.closeGuidePopup();
-        starterPage.setPayaraPlatform("Payara Micro", "6.2025.1", "6.2025.1");
-        starterPage.setProjectConfiguration("fish.payara.e2e", false, "Java SE 21", "21");
-        starterPage.setMicroProfile("Full MP");
-        starterPage.setDeployment(true, false);
-        starterPage.setERDiagram("", true, "domain", false, "service", false, "resource", "HTML", "html");
-        starterPage.setSecurity("Form Authentication - File Realm");
-        starterPage.generate(page, Paths.get("./target/test-app-gradle", "HelloWorldJdk21.zip"));
-
-        FileManagement.unzip("./target/test-app-gradle/HelloWorldJdk21.zip", "./target/test-app-gradle/HelloWorldJdk21");
-        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-gradle/HelloWorldJdk21/build.gradle")));
-        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-gradle/HelloWorldJdk21/build.gradle"),
-                "sourceCompatibility = JavaVersion.VERSION_21"));
-    }*/
 
     @Test
     void mavenJdk11InventorySystem() throws InterruptedException, IOException {

--- a/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/SecurityOptionsIT.java
+++ b/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/SecurityOptionsIT.java
@@ -87,65 +87,59 @@ public class SecurityOptionsIT {
     }
 
     @Test
-    void mavenJdk11InventorySystem() throws InterruptedException, IOException {
-        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "InventorySystemTestJdk11", "1.0-SNAPSHOT");
-        starterPage.setJakartaEE("Jakarta EE 8", "8", "Web Profile");
-        starterPage.closeGuidePopup();
-        starterPage.setPayaraPlatform("Payara Server", "5.2022.5", "5.2022.5");
-        starterPage.setProjectConfiguration("fish.payara.e2e", true, "Java SE 11", "11");
-        starterPage.setMicroProfile("MicroProfile Metrics");
-        starterPage.setDeployment(false, false);
-        starterPage.setERDiagram("Inventory System", true, "domain", false, "service", false, "resource", "HTML", "html");
-        starterPage.openERDiagramPreview();
-        starterPage.checkDiagramCodeContains("PRODUCT ||--o{ INVENTORY : contains");
-        starterPage.checkDiagramGraphContains("INVENTORY");
-        starterPage.closeERDiagramPreview();
-        starterPage.setSecurity("None");
-        starterPage.generate(page, Paths.get("./target/test-app-maven", "InventorySystemTestJdk11.zip"));
-
-        FileManagement.unzip("./target/test-app-maven/InventorySystemTestJdk11.zip", "./target/test-app-maven/InventorySystemTestJdk11");
-        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/InventorySystemTestJdk11/pom.xml")));
-        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/InventorySystemTestJdk11/pom.xml"),
-                "<maven.compiler.release>11</maven.compiler.release>"));
-    }
-
-    @Test
-    void mavenJdk17ProductCatalog() throws InterruptedException, IOException {
-        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "ProductCatalogJdk17", "1.0-SNAPSHOT");
-        starterPage.setJakartaEE("Jakarta EE 9", "9", "Web Profile");
-        starterPage.closeGuidePopup();
+    void PayaraServer6EE10Jdk17SecuFileRealm() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "PayaraServer6EE10Jdk17SecuFileRealm", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Platform");
         starterPage.setPayaraPlatform("Payara Server", "6.2025.1", "6.2025.1");
-        starterPage.setProjectConfiguration("fish.payara.e2e", true, "Java SE 17", "17");
-        starterPage.setMicroProfile("MicroProfile Metrics");
+        starterPage.closeGuidePopup();
+        starterPage.setProjectConfiguration("fish.payara.test", false, "Java SE 17", "17");
+        starterPage.setMicroProfile("");
         starterPage.setDeployment(false, false);
-        starterPage.setERDiagram("Product Catalog", true, "domain", false, "service", false, "resource", "HTML", "html");
-        starterPage.setSecurity("None");
-        starterPage.generate(page, Paths.get("./target/test-app-maven", "ProductCatalogJdk17.zip"));
+        starterPage.setERDiagram("", false, "domain", false, "service", false, "resource", "None", "none");
+        starterPage.setSecurity("Form Authentication - File Realm");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "PayaraServer6EE10Jdk17SecuFileRealm.zip"));
 
-        FileManagement.unzip("./target/test-app-maven/ProductCatalogJdk17.zip", "./target/test-app-maven/ProductCatalogJdk17");
-        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/ProductCatalogJdk17/pom.xml")));
-        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/ProductCatalogJdk17/pom.xml"),
+        FileManagement.unzip("./target/test-app-maven/PayaraServer6EE10Jdk17SecuFileRealm.zip", "./target/test-app-maven/PayaraServer6EE10Jdk17SecuFileRealm");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/PayaraServer6EE10Jdk17SecuFileRealm/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/PayaraServer6EE10Jdk17SecuFileRealm/pom.xml"),
                 "<maven.compiler.release>17</maven.compiler.release>"));
     }
 
-    /*@Test
-    // Disabled - provided gradle wrapper fails to compile with jdk21 - FISH-11064
-    So we need to run the tests with jdk 17
-    void mavenJdk21EnergyManagementSystem() throws InterruptedException, IOException {
-        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "EnergyManagementSystemJdk21", "1.0-SNAPSHOT");
-        starterPage.setJakartaEE("Jakarta EE 10", "10", "Web Profile");
+    @Test
+    void PayaraServer6EE10Jdk17SecuDB() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "PayaraServer6EE10Jdk17SecuDB", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Platform");
+        starterPage.setPayaraPlatform("Payara Server", "6.2025.1", "6.2025.1");
         starterPage.closeGuidePopup();
-        starterPage.setPayaraPlatform("Payara Server", "6.2024.12", "6.2024.12");
-        starterPage.setProjectConfiguration("fish.payara.e2e", true, "Java SE 21", "21");
-        starterPage.setMicroProfile("MicroProfile Metrics");
+        starterPage.setProjectConfiguration("fish.payara.test", false, "Java SE 17", "17");
+        starterPage.setMicroProfile("");
         starterPage.setDeployment(false, false);
-        starterPage.setERDiagram("Energy Management System", false, "domain", false, "service", false, "resource", "HTML", "html");
-        starterPage.setSecurity("None");
-        starterPage.generate(page, Paths.get("./target/test-app-maven", "EnergyManagementSystemJdk21.zip"));
+        starterPage.setERDiagram("", false, "domain", false, "service", false, "resource", "None", "none");
+        starterPage.setSecurity("Form Authentication - Database");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "PayaraServer6EE10Jdk17SecuDB.zip"));
 
-        FileManagement.unzip("./target/test-app-maven/EnergyManagementSystemJdk21.zip", "./target/test-app-maven/EnergyManagementSystemJdk21");
-        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/EnergyManagementSystemJdk21/pom.xml")));
-        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/EnergyManagementSystemJdk21/pom.xml"),
-                "<maven.compiler.release>21</maven.compiler.release>"));
-    }*/
+        FileManagement.unzip("./target/test-app-maven/PayaraServer6EE10Jdk17SecuDB.zip", "./target/test-app-maven/PayaraServer6EE10Jdk17SecuDB");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/PayaraServer6EE10Jdk17SecuDB/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/PayaraServer6EE10Jdk17SecuDB/pom.xml"),
+                "<maven.compiler.release>17</maven.compiler.release>"));
+    }
+
+    @Test
+    void PayaraServer6EE10Jdk17SecuLdap() throws InterruptedException, IOException {
+        starterPage.setProjectDescription("Maven", "fish.payara.playwright.test", "PayaraServer6EE10Jdk17SecuLdap", "1.0-SNAPSHOT");
+        starterPage.setJakartaEE("Jakarta EE 10", "10", "Platform");
+        starterPage.setPayaraPlatform("Payara Server", "6.2025.1", "6.2025.1");
+        starterPage.closeGuidePopup();
+        starterPage.setProjectConfiguration("fish.payara.test", false, "Java SE 17", "17");
+        starterPage.setMicroProfile("");
+        starterPage.setDeployment(false, false);
+        starterPage.setERDiagram("", false, "domain", false, "service", false, "resource", "None", "none");
+        starterPage.setSecurity("Form Authentication - LDAP");
+        starterPage.generate(page, Paths.get("./target/test-app-maven", "PayaraServer6EE10Jdk17SecuLdap.zip"));
+
+        FileManagement.unzip("./target/test-app-maven/PayaraServer6EE10Jdk17SecuLdap.zip", "./target/test-app-maven/PayaraServer6EE10Jdk17SecuLdap");
+        assertTrue(FileManagement.checkFilePresence(new File("./target/test-app-maven/PayaraServer6EE10Jdk17SecuLdap/pom.xml")));
+        assertTrue(FileManagement.checkFileContains(new File("./target/test-app-maven/PayaraServer6EE10Jdk17SecuLdap/pom.xml"),
+                "<maven.compiler.release>17</maven.compiler.release>"));
+    }
 }

--- a/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/SecurityOptionsIT.java
+++ b/starter-ui/src/test/java/fish/payara/starter/test/e2e/specs/SecurityOptionsIT.java
@@ -69,7 +69,7 @@ public class SecurityOptionsIT {
         context = browser.newContext();
         page = context.newPage();
         page.setDefaultTimeout(90000);
-        page.navigate("http://localhost:8080/payara-starter");
+        page.navigate("http://localhost:8082/payara-starter");
         page.waitForSelector("div.hero", new Page.WaitForSelectorOptions().setTimeout(120000));
 
         starterPage = new StarterPageActions(page);


### PR DESCRIPTION
Add many test scenarios to cover multiple combinations in Payara Starter.

This PR also fixes the port to run payara-micro-maven-plugin to 8082. This is so the tests can generate applications, unzip them and run `mvn verify` in the generated application which in turn will start its own instance of Payara server to deploy the generated application, using the ports 8080 and 8081.

Steps to run the tests:
`<ecosystem-starter>./mvn clean install payara-micro:start -f .\starter-ui\ -DcontextRoot="payara-starter" -DdeployWar=true`
`<ecosystem-starter/starter-ui>./mvn clean verify -De2e`