### PR TITLE
FISH-11246 - test generated app

### DIFF
--- a/starter-ui/pom.xml
+++ b/starter-ui/pom.xml
@@ -362,7 +362,7 @@
                                             <![CDATA[
                                             for dir in ./target/test-app-maven/*; do 
                                                 if [ -d "$dir" ]; then 
-                                                    (cd "$dir" && mvn verify -B && mvn clean -q
+                                                    (cd "$dir" && mvn verify -B && mvn clean -q)
                                                 fi; 
                                             done
                                             ]]>


### PR DESCRIPTION
The e2e tests generate various applications via Payara Starter, unzip the generated apps and run `mvn verify` for each of the generated app to compile and run the Arquillian tests generated for these applications.
Because each application will download its own version of Payara server/micro to run its tests, the disk usage can become really problematic. This is why I added a `mvn clean` after the test run for each application, to clean up the compiled files and the payara files for that generated app. 
The application with gradle do not have tests, so we only compile them.

Known issue: some tests are throwing warnings when run, yet the test is successful: https://payara.atlassian.net/browse/FISH-11347

how to run the tests:
{ecosystem-starter}/mvn clean install payara-micro:start -f .\starter-ui\ -DcontextRoot="payara-starter" -DdeployWar=true
{ecosystem-starter/starter-ui}/mvn clean verify -De2e