### PR TITLE
FISH-11021 - add stage to test in jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,5 +28,24 @@ pipeline {
                 }
             }
         }
+        stage('Test Payara Starter') {
+            environment {
+                JAVA_HOME = tool("zulu-17")
+                PATH = "${env.JAVA_HOME}/bin:${env.PATH}"
+                MAVEN_OPTS = '-Xmx2G -Djavax.net.ssl.trustStore=${JAVA_HOME}/jre/lib/security/cacerts'
+                payaraBuildNumber = "${BUILD_NUMBER}"
+            }
+            steps {
+                script {
+                    sh '''
+                    echo *#*#*#*#*#*#*#*#*#*#*#*#  Deploying Payara Starter  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*
+                    mvn clean install payara-micro:start -f ./starter-ui/ \
+                        -DcontextRoot="payara-starter" -DdeployWar=true
+                    echo *#*#*#*#*#*#*#*#*#*#*#*#  Testing Payara Starter  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*
+                    mvn clean verify -f ./starter-ui/ -De2e
+                    '''
+                }
+            }
+        }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,10 +20,10 @@ pipeline {
             steps {
                 script {
                     sh '''
-                    echo *#*#*#*#*#*#*#*#*#*#*#*#  Building SRC  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*
-                    mvn -B -V -ff -e clean install --strict-checksums \
-                        -Djavadoc.skip -Dsource.skip
-                    echo *#*#*#*#*#*#*#*#*#*#*#*#    Built SRC   *#*#*#*#*#*#*#*#*#*#*#*#*#*#*
+                    echo *#*#*#*#*#*#*#*#*#*#*#*#  Building SRC  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*'''
+                    sh '''mvn -B -V -ff -e clean install --strict-checksums \
+                        -Djavadoc.skip -Dsource.skip'''
+                    sh '''echo *#*#*#*#*#*#*#*#*#*#*#*#    Built SRC   *#*#*#*#*#*#*#*#*#*#*#*#*#*#*
                     '''
                 }
             }
@@ -36,14 +36,22 @@ pipeline {
                 payaraBuildNumber = "${BUILD_NUMBER}"
             }
             steps {
+                withCredentials([string(credentialsId: 'open-ai-payara-starter-token', variable: 'PAYARA_TOKEN')]) {
                 script {
-                    sh '''
-                    echo *#*#*#*#*#*#*#*#*#*#*#*#  Deploying Payara Starter  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*
-                    mvn clean install payara-micro:start -f ./starter-ui/ \
-                        -DcontextRoot="payara-starter" -DdeployWar=true
-                    echo *#*#*#*#*#*#*#*#*#*#*#*#  Testing Payara Starter  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*
-                    mvn clean verify -f ./starter-ui/ -De2e
-                    '''
+                    sh '''echo *#*#*#*#*#*#*#*#*#*#*#*#  Add OPEN_API_KEY to microprofile-config.properties  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*'''
+                    sh '''echo "\n OPEN_API_KEY=$PAYARA_TOKEN" >> starter-ui/src/main/resources/META-INF/microprofile-config.properties'''
+
+                    sh '''echo *#*#*#*#*#*#*#*#*#*#*#*#  Deploying Payara Starter  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*'''
+                    sh '''mvn clean install payara-micro:start -f ./starter-ui/ \
+                        -DcontextRoot="payara-starter" -DdeployWar=true > payara.log 2>&1 &
+                    echo $! > payara.pid'''
+                    sh '''echo *#*#*#*#*#*#*#*#*#*#*#*#  Testing Payara Starter  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*'''
+                    sh '''sleep 150'''
+                    sh '''sudo mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install-deps"'''
+                    sh '''mvn clean verify -f ./starter-ui/ -De2e'''
+                    sh '''echo *#*#*#*#*#*#*#*#*#*#*#*#  Stopping Payara Micro  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*'''
+                    sh 'kill $(cat payara.pid)'
+                    }
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,8 +19,7 @@ pipeline {
             }
             steps {
                 script {
-                    sh '''
-                    echo *#*#*#*#*#*#*#*#*#*#*#*#  Building SRC  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*'''
+                    sh '''echo *#*#*#*#*#*#*#*#*#*#*#*#  Building SRC  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*'''
                     sh '''mvn -B -V -ff -e clean install --strict-checksums \
                         -Djavadoc.skip -Dsource.skip'''
                     sh '''echo *#*#*#*#*#*#*#*#*#*#*#*#    Built SRC   *#*#*#*#*#*#*#*#*#*#*#*#*#*#*
@@ -28,29 +27,51 @@ pipeline {
                 }
             }
         }
-        stage('Test Payara Starter') {
-            environment {
-                JAVA_HOME = tool("zulu-17")
-                PATH = "${env.JAVA_HOME}/bin:${env.PATH}"
-                MAVEN_OPTS = '-Xmx2G -Djavax.net.ssl.trustStore=${JAVA_HOME}/jre/lib/security/cacerts'
-                payaraBuildNumber = "${BUILD_NUMBER}"
-            }
-            steps {
-                withCredentials([string(credentialsId: 'open-ai-payara-starter-token', variable: 'PAYARA_TOKEN')]) {
-                script {
-                    sh '''echo *#*#*#*#*#*#*#*#*#*#*#*#  Add OPEN_API_KEY to microprofile-config.properties  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*'''
-                    sh '''echo "\n OPEN_API_KEY=$PAYARA_TOKEN" >> starter-ui/src/main/resources/META-INF/microprofile-config.properties'''
-
-                    sh '''echo *#*#*#*#*#*#*#*#*#*#*#*#  Deploying Payara Starter  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*'''
-                    sh '''mvn clean install payara-micro:start -f ./starter-ui/ \
-                        -DcontextRoot="payara-starter" -DdeployWar=true > payara.log 2>&1 &
-                    echo $! > payara.pid'''
-                    sh '''echo *#*#*#*#*#*#*#*#*#*#*#*#  Testing Payara Starter  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*'''
-                    sh '''sleep 150'''
-                    sh '''cd starter-ui'''
-                    sh '''mvn verify -De2e -Dmaven.javadoc.skip=true -Pinstall-deps '''
-                    sh '''echo *#*#*#*#*#*#*#*#*#*#*#*#  Stopping Payara Micro  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*'''
-                    sh 'kill $(cat payara.pid)'
+        stage('Test'){
+            parallel {
+                stage('Deploy Starter UI') {
+                    environment {
+                        JAVA_HOME = tool("zulu-17")
+                        PATH = "${env.JAVA_HOME}/bin:${env.PATH}"
+                        MAVEN_OPTS = '-Xmx2G -Djavax.net.ssl.trustStore=${JAVA_HOME}/jre/lib/security/cacerts'
+                        payaraBuildNumber = "${BUILD_NUMBER}"
+                    }
+                    steps {
+                        withCredentials([string(credentialsId: 'open-ai-payara-starter-token', variable: 'PAYARA_TOKEN')]) {
+                        script {
+                            sh '''echo *#*#*#*#*#*#*#*#*#*#*#*#  Add OPEN_API_KEY to microprofile-config.properties  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*'''
+                            sh '''echo "\n OPEN_API_KEY=$PAYARA_TOKEN" >> starter-ui/src/main/resources/META-INF/microprofile-config.properties'''
+                            sh '''echo *#*#*#*#*#*#*#*#*#*#*#*#  Deploying Payara Starter  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*'''
+                            sh '''mvn clean install payara-micro:start -f ./starter-ui/ \
+                                -DcontextRoot="payara-starter" -DdeployWar=true > payara.log 2>&1 &
+                            echo $! > $WORKSPACE/payara.pid'''
+                            }
+                        }
+                    }
+                }
+                stage('Test Starter UI') {
+                    environment {
+                        JAVA_HOME = tool("zulu-17")
+                        PATH = "${env.JAVA_HOME}/bin:${env.PATH}"
+                        MAVEN_OPTS = '-Xmx2G -Djavax.net.ssl.trustStore=${JAVA_HOME}/jre/lib/security/cacerts'
+                        payaraBuildNumber = "${BUILD_NUMBER}"
+                    }
+                    steps {
+                        script {                 
+                            timeout(time: 5, unit: 'MINUTES') {
+                                waitUntil(initialRecurrencePeriod: 10000){
+                                    fileExists('payara.log') && readFile('payara.log').contains('Payara Micro URLs:')
+                                }
+                            }
+                            sh '''echo *#*#*#*#*#*#*#*#*#*#*#*#  Testing Payara Starter  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*'''
+                            sh '''cd starter-ui'''
+                            sh '''mvn verify -De2e -Dmaven.javadoc.skip=true -Pinstall-deps '''
+                            }
+                        }
+                    post {
+                        always {
+                            sh 'while ps -p $(cat $WORKSPACE/payara.pid); do sudo kill -9 $(cat $WORKSPACE/payara.pid); sleep 5; done'
+                        }
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,7 @@ pipeline {
                     steps {
                         script {                 
                             timeout(time: 5, unit: 'MINUTES') {
-                                waitUntil(initialRecurrencePeriod: 10000){
+                                waitUntil(initialRecurrencePeriod: 15000){
                                     fileExists('payara.log') && readFile('payara.log').contains('Payara Micro URLs:')
                                 }
                             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,8 +47,8 @@ pipeline {
                     echo $! > payara.pid'''
                     sh '''echo *#*#*#*#*#*#*#*#*#*#*#*#  Testing Payara Starter  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*'''
                     sh '''sleep 150'''
-                    sh '''sudo mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install-deps"'''
-                    sh '''mvn clean verify -f ./starter-ui/ -De2e'''
+                    sh '''cd starter-ui'''
+                    sh '''mvn verify -De2e -Dmaven.javadoc.skip=true -Pinstall-deps '''
                     sh '''echo *#*#*#*#*#*#*#*#*#*#*#*#  Stopping Payara Micro  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*'''
                     sh 'kill $(cat payara.pid)'
                     }

--- a/starter-ui/pom.xml
+++ b/starter-ui/pom.xml
@@ -401,5 +401,36 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>install-deps</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.5.0</version>
+                        <executions>
+                          <execution>
+                            <id>install-playwright-dependencies</id>
+                            <phase>pre-integration-test</phase>
+                            <goals>
+                              <goal>exec</goal>
+                            </goals>
+                          </execution>
+                        </executions>
+                        <configuration>
+                            <executable>java</executable>
+                            <mainClass>com.microsoft.playwright.CLI</mainClass>
+                            <arguments>
+                                <argument>-classpath</argument>
+                                <classpath />
+                                <argument>com.microsoft.playwright.CLI</argument>
+                                <argument>install-deps</argument>
+                            </arguments>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>         
+        </profile> 
     </profiles>
 </project>


### PR DESCRIPTION
PR to run the e2e tests in Payara Starter pipeline.
One stage to add the OPEN API KEY to the properties file, then build and deploy payara starter ui to payara micro
One stage to run the tests once the app is deployed in payara micro.
It takes about 23 minutes to deploy and run the tests for Payara Starter at the moment.

The separation in two stages is mainly an esthetic choice, the tests cannot run before the deployment is ready, but the stage with the tests will kill payara micro at the end of the tests. Although having the stages running in parallel could also enable to run different tests in parallel in the future. 
Because the step deploying the app has to be run in background, Jenkins considers the step completed immediately, no matter its output/result. So inspecting its exported output is necessary to determine when the deployment is successful and the app ready to be tested.
Killing payara micro at the end of the tests is make sure that the process is not left hanging, in case we would want to add another stage after these tests in the future. At the moment, it may not necessary as Jenkins would tear down the agent after the tests are over (as it considers the deployment step over already). 