### PR TITLE
FISH-10973 JSF template support - relationship attributes 

### DIFF
--- a/starter-generator/src/main/java/fish/payara/starter/application/domain/Attribute.java
+++ b/starter-generator/src/main/java/fish/payara/starter/application/domain/Attribute.java
@@ -329,6 +329,18 @@ public class Attribute {
     public String getApiUrl() {
         return kebabCase(firstLower(type));
     }
+    
+    public String getConverter() {
+        return firstLower(type) + "Converter";
+    }
+    
+    public String getBean() {
+        return firstLower(type) + "Bean";
+    }
+    
+    public String getPluralType() {
+        return pluralize(type);
+    }
 
     @Override
     public String toString() {

--- a/starter-generator/src/main/java/fish/payara/starter/application/domain/Attribute.java
+++ b/starter-generator/src/main/java/fish/payara/starter/application/domain/Attribute.java
@@ -59,6 +59,7 @@ import static fish.payara.starter.application.util.AttributeType.LOCAL_DATE_TIME
 import static fish.payara.starter.application.util.StringUtils.firstLower;
 import static fish.payara.starter.application.util.StringUtils.firstUpper;
 import static fish.payara.starter.application.util.StringUtils.kebabCase;
+import static fish.payara.starter.application.util.StringUtils.pluralize;
 import static fish.payara.starter.application.util.StringUtils.startCase;
 import jakarta.json.bind.annotation.JsonbTransient;
 import jakarta.json.bind.annotation.JsonbTypeSerializer;
@@ -78,7 +79,7 @@ public class Attribute {
     private boolean multi;
     private boolean required;
     private String tooltip;
-    private Boolean display;
+    private boolean display;
     private String htmlLabel;
 
     /** Default constructor for Attribute. */
@@ -138,6 +139,16 @@ public class Attribute {
     @JsonbTransient
     public String getTitleCaseName() {
         return firstUpper(name);
+    }
+
+    /**
+     * Returns the name of the attribute in plural case format.
+     *
+     * @return the plural case name
+     */
+    @JsonbTransient
+    public String getPluralName() {
+        return pluralize(firstUpper(name));
     }
 
     /** 
@@ -250,7 +261,7 @@ public class Attribute {
      * @return true if the attribute is to be displayed, false otherwise
      */
     @JsonbTransient
-    public Boolean isDisplay() {
+    public boolean isDisplay() {
         return display;
     }
 
@@ -259,7 +270,7 @@ public class Attribute {
      * 
      * @param display true if the attribute should be displayed, false otherwise
      */
-    public void setDisplay(Boolean display) {
+    public void setDisplay(boolean display) {
         this.display = display;
     }
 

--- a/starter-generator/src/main/java/fish/payara/starter/application/domain/Entity.java
+++ b/starter-generator/src/main/java/fish/payara/starter/application/domain/Entity.java
@@ -143,7 +143,7 @@ public class Entity {
     @JsonbTransient
     public String getDisplayName() {
         String displayName = attributes.stream()
-                .filter(a -> a.isDisplay() != null && a.isDisplay())
+                .filter(a -> a.isDisplay())
                 .map(a -> a.getName()).findFirst().orElse(null);
         if(displayName == null) {
             displayName = attributes.stream()

--- a/starter-generator/src/main/java/fish/payara/starter/application/generator/CRUDAppGenerator.java
+++ b/starter-generator/src/main/java/fish/payara/starter/application/generator/CRUDAppGenerator.java
@@ -233,6 +233,7 @@ public class CRUDAppGenerator {
             Configuration cfg = createFreemarkerConfiguration("template/jsf");
 
             Map<String, Object> dataModel = new HashMap<>();
+            dataModel.put("model", model);
             dataModel.put("package", _package + "." + CONVERTER);
             processTemplateToFile(cfg, "LocalDateConverter.java.ftl", dataModel, outputDir, "LocalDateConverter.java");
             processTemplateToFile(cfg, "LocalDateTimeConverter.java.ftl", dataModel, outputDir, "LocalDateTimeConverter.java");

--- a/starter-generator/src/main/resources/template/jsf/EntityBean.java.ftl
+++ b/starter-generator/src/main/resources/template/jsf/EntityBean.java.ftl
@@ -15,10 +15,10 @@
 -->
 package ${package};
 
-import jakarta.annotation.PostConstruct;
-import jakarta.inject.Named;
-import jakarta.inject.Inject;
-import jakarta.faces.view.ViewScoped;
+import ${model.importPrefix}.annotation.PostConstruct;
+import ${model.importPrefix}.inject.Named;
+import ${model.importPrefix}.inject.Inject;
+import ${model.importPrefix}.faces.view.ViewScoped;
 import java.io.Serializable;
 import java.util.List;
 

--- a/starter-generator/src/main/resources/template/jsf/EntityConverter.java.ftl
+++ b/starter-generator/src/main/resources/template/jsf/EntityConverter.java.ftl
@@ -1,0 +1,71 @@
+<#-- 
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) [2025] Payara Foundation and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://github.com/payara/Payara/blob/master/LICENSE.txt
+    See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at glassfish/legal/LICENSE.txt.
+
+    GPL Classpath Exception:
+    The Payara Foundation designates this particular file as subject to the "Classpath"
+    exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+-->
+package ${package};
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.convert.Converter;
+import jakarta.faces.convert.FacesConverter;
+import jakarta.inject.Inject;
+import ${EntityClass_FQN};
+import ${EntityRepository_FQN};
+
+@FacesConverter(value = "${entityConverterName}", managed = true)
+public class ${entityConverterClass} implements Converter<${instanceType}> {
+
+    @Inject
+    private ${EntityRepository} ${entityRepository};
+
+    @Override
+    public ${instanceType} getAsObject(FacesContext context, UIComponent component, String value) {
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+        return ${entityRepository}.find(${pkType}.valueOf(value));
+    }
+
+    @Override
+    public String getAsString(FacesContext context, UIComponent component, ${instanceType} ${instanceName}) {
+        if (${instanceName} == null || ${instanceName}.${pkGetter}() == null) {
+            return "";
+        }
+        return ${instanceName}.${pkGetter}().toString();
+    }
+}

--- a/starter-generator/src/main/resources/template/jsf/EntityConverter.java.ftl
+++ b/starter-generator/src/main/resources/template/jsf/EntityConverter.java.ftl
@@ -39,11 +39,11 @@
 -->
 package ${package};
 
-import jakarta.faces.component.UIComponent;
-import jakarta.faces.context.FacesContext;
-import jakarta.faces.convert.Converter;
-import jakarta.faces.convert.FacesConverter;
-import jakarta.inject.Inject;
+import ${model.importPrefix}.faces.component.UIComponent;
+import ${model.importPrefix}.faces.context.FacesContext;
+import ${model.importPrefix}.faces.convert.Converter;
+import ${model.importPrefix}.faces.convert.FacesConverter;
+import ${model.importPrefix}.inject.Inject;
 import ${EntityClass_FQN};
 import ${EntityRepository_FQN};
 

--- a/starter-generator/src/main/resources/template/jsf/LocalDateConverter.java.ftl
+++ b/starter-generator/src/main/resources/template/jsf/LocalDateConverter.java.ftl
@@ -39,10 +39,10 @@
 -->
 package ${package};
 
-import jakarta.faces.component.UIComponent;
-import jakarta.faces.context.FacesContext;
-import jakarta.faces.convert.Converter;
-import jakarta.faces.convert.FacesConverter;
+import ${model.importPrefix}.faces.component.UIComponent;
+import ${model.importPrefix}.faces.context.FacesContext;
+import ${model.importPrefix}.faces.convert.Converter;
+import ${model.importPrefix}.faces.convert.FacesConverter;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 

--- a/starter-generator/src/main/resources/template/jsf/LocalDateTimeConverter.java.ftl
+++ b/starter-generator/src/main/resources/template/jsf/LocalDateTimeConverter.java.ftl
@@ -39,10 +39,10 @@
 -->
 package ${package};
 
-import jakarta.faces.component.UIComponent;
-import jakarta.faces.context.FacesContext;
-import jakarta.faces.convert.Converter;
-import jakarta.faces.convert.FacesConverter;
+import ${model.importPrefix}.faces.component.UIComponent;
+import ${model.importPrefix}.faces.context.FacesContext;
+import ${model.importPrefix}.faces.convert.Converter;
+import ${model.importPrefix}.faces.convert.FacesConverter;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 

--- a/starter-generator/src/main/resources/template/jsf/NavigationBean.java.ftl
+++ b/starter-generator/src/main/resources/template/jsf/NavigationBean.java.ftl
@@ -39,8 +39,8 @@
 -->
 package ${package};
 
-import jakarta.enterprise.context.SessionScoped;
-import jakarta.inject.Named;
+import ${model.importPrefix}.enterprise.context.SessionScoped;
+import ${model.importPrefix}.inject.Named;
 import java.io.Serializable;
 
 @Named

--- a/starter-generator/src/main/resources/template/jsf/about-us.xhtml.ftl
+++ b/starter-generator/src/main/resources/template/jsf/about-us.xhtml.ftl
@@ -38,8 +38,13 @@
     holder.
 -->
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
+<#if model.importPrefix == "jakarta" >
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
+ <#else>
+                xmlns:ui="http://java.sun.com/jsf/facelets"
+                xmlns:h="http://java.sun.com/jsf/html"
+</#if>
                 template="/WEB-INF/layout/template.xhtml">
 
     <ui:define name="pageTitle">About Us</ui:define>

--- a/starter-generator/src/main/resources/template/jsf/entity.xhtml.ftl
+++ b/starter-generator/src/main/resources/template/jsf/entity.xhtml.ftl
@@ -10,26 +10,43 @@
             <p>${entity.getDescription()}</p>
             <h:panelGrid columns="2" columnClasses="label,value" styleClass="table-form">
             <#list entity.attributes as attribute>
-                <#if !attribute.multi>
-                <h:outputLabel for="${attribute.getName()}" value="${attribute.getStartCaseName()}:" />
-                <#if attribute.type == "LocalDateTime">
-                <h:inputText id="${attribute.getName()}" 
-                            value="${'#' + '{'+ beanName + '.' + entityNameLowerCase + '.' + attribute.name + '}'}" 
-                            converter="localDateTimeConverter">
-                    <f:passThroughAttribute name="type" value="datetime-local" />
+            <#if !(attribute.primaryKey && attribute.type != "String") && !attribute.multi>
+                <#assign attrId = attribute.getName()>
+                <#assign attrValue = beanName + '.' + entityNameLowerCase + '.' + attribute.name>
+
+                <h:outputLabel for="${attrId}" value="${attribute.getStartCaseName()}:" />
+                <#if model.getEntity(attribute.type)??>
+                <h:selectOneMenu id="${attrId}"
+                                 value="${'#{' + attrValue + '}'}"
+                                 converter="${attribute.type?lower_case}Converter">
+                    <f:selectItem itemLabel="Select ${attribute.getTitleCaseName()}" noSelectionOption="true" />
+                    <f:selectItems value="${'#{' + attribute.name + 'Bean.all' + attribute.getPluralName() + '}'}"
+                                   var="${attrId}"
+                                   itemValue="${'#{' + attrId + '}'}"
+                                   itemLabel="${'#{' + attrId + '}'}" />
+                </h:selectOneMenu>
+                <#elseif attribute.type == "LocalDateTime" || attribute.type == "LocalDate">
+                <h:inputText id="${attrId}" 
+                             value="${'#{' + attrValue + '}'}" 
+                             converter="${attribute.type?lower_case}Converter">
+                    <f:passThroughAttribute name="type" value="${attribute.type == 'LocalDateTime'?string('datetime-local', 'date')}" />
                 </h:inputText>
-                <#elseif attribute.type == "LocalDate">
-                <h:inputText id="${attribute.getName()}" 
-                             value="${'#' + '{' + beanName + '.' + entityNameLowerCase + '.' + attribute.name + '}'}" 
-                             converter="localDateConverter">
-                    <f:passThroughAttribute name="type" value="date" />
+                <#elseif attribute.isNumber()>
+                <h:inputText id="${attrId}" value="${'#{' + attrValue + '}'}" />
+                    <f:passThroughAttribute name="type" value="number" />
                 </h:inputText>
                 <#else>
-                <h:inputText id="${attribute.getName()}" value="${'#' + '{'+ beanName + '.' + entityNameLowerCase + '.' + attribute.name + '}'}" />
+                <h:inputText id="${attrId}" value="${'#{' + attrValue + '}'}" />
                 </#if>
-                </#if>
+            </#if>
             </#list>
             </h:panelGrid>
+            <#list entity.attributes as attribute>
+            <#if attribute.primaryKey && attribute.type != "String">
+            <h:inputHidden id="${attribute.getName()}" 
+                           value="${'#' + '{'+ beanName + '.' + entityNameLowerCase + '.' + attribute.name + '}'}" />
+            </#if>
+            </#list>
 
             <h:commandButton value="Save" action="${'#' + '{'+ beanName + '.save}'}" styleClass="btn btn-primary mt-3" />
 

--- a/starter-generator/src/main/resources/template/jsf/entity.xhtml.ftl
+++ b/starter-generator/src/main/resources/template/jsf/entity.xhtml.ftl
@@ -1,7 +1,13 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
+<#if model.importPrefix == "jakarta" >
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:f="jakarta.faces.core"
                 xmlns:h="jakarta.faces.html"
+ <#else>
+                xmlns:ui="http://java.sun.com/jsf/facelets"
+                xmlns:f="http://java.sun.com/jsf/core"
+                xmlns:h="http://java.sun.com/jsf/html"
+</#if>
                 template="/WEB-INF/layout/template.xhtml">
 
     <ui:define name="content">
@@ -18,9 +24,9 @@
                 <#if model.getEntity(attribute.type)??>
                 <h:selectOneMenu id="${attrId}"
                                  value="${'#{' + attrValue + '}'}"
-                                 converter="${attribute.type?lower_case}Converter">
-                    <f:selectItem itemLabel="Select ${attribute.getTitleCaseName()}" noSelectionOption="true" />
-                    <f:selectItems value="${'#{' + attribute.name + 'Bean.all' + attribute.getPluralName() + '}'}"
+                                 converter="${attribute.converter}">
+                    <f:selectItem itemLabel="Select ${attribute.titleCaseName}" noSelectionOption="true" />
+                    <f:selectItems value="${'#{' + attribute.bean + '.all' + attribute.pluralType + '}'}"
                                    var="${attrId}"
                                    itemValue="${'#{' + attrId + '}'}"
                                    itemLabel="${'#{' + attrId + '}'}" />
@@ -28,8 +34,8 @@
                 <#elseif attribute.type == "LocalDateTime" || attribute.type == "LocalDate">
                 <h:inputText id="${attrId}" 
                              value="${'#{' + attrValue + '}'}" 
-                             converter="${attribute.type?lower_case}Converter">
-                    <f:passThroughAttribute name="type" value="${attribute.type == 'LocalDateTime'?string('datetime-local', 'date')}" />
+                             converter="${attribute.converter}">
+                    <f:passThroughAttribute name="type" value="${(attribute.type == 'LocalDateTime')?string('datetime-local', 'date')}" />
                 </h:inputText>
                 <#elseif attribute.isNumber()>
                 <h:inputText id="${attrId}" value="${'#{' + attrValue + '}'}" >

--- a/starter-generator/src/main/resources/template/jsf/entity.xhtml.ftl
+++ b/starter-generator/src/main/resources/template/jsf/entity.xhtml.ftl
@@ -32,7 +32,7 @@
                     <f:passThroughAttribute name="type" value="${attribute.type == 'LocalDateTime'?string('datetime-local', 'date')}" />
                 </h:inputText>
                 <#elseif attribute.isNumber()>
-                <h:inputText id="${attrId}" value="${'#{' + attrValue + '}'}" />
+                <h:inputText id="${attrId}" value="${'#{' + attrValue + '}'}" >
                     <f:passThroughAttribute name="type" value="number" />
                 </h:inputText>
                 <#else>

--- a/starter-generator/src/main/resources/template/jsf/footer.xhtml.ftl
+++ b/starter-generator/src/main/resources/template/jsf/footer.xhtml.ftl
@@ -38,7 +38,11 @@
     holder.
 -->
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
+<#if model.importPrefix == "jakarta" >
                 xmlns:ui="jakarta.faces.facelets"
+ <#else>
+                xmlns:ui="http://java.sun.com/jsf/facelets"
+</#if>
 >
 
     <footer class="fixed-bottom mt-auto py-3" id="footer">

--- a/starter-generator/src/main/resources/template/jsf/header.xhtml.ftl
+++ b/starter-generator/src/main/resources/template/jsf/header.xhtml.ftl
@@ -38,10 +38,17 @@
     holder.
 -->
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
-                xmlns:pt="http://xmlns.jcp.org/jsf/passthrough"
+<#if model.importPrefix == "jakarta" >
+                xmlns:pt="http://xmlns.jakarta.org/jsf/passthrough"
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:f="jakarta.faces.core"
                 xmlns:h="jakarta.faces.html">
+ <#else>
+                xmlns:pt="http://xmlns.jcp.org/jsf/passthrough"
+                xmlns:ui="http://java.sun.com/jsf/facelets"
+                xmlns:f="http://java.sun.com/jsf/core"
+                xmlns:h="http://java.sun.com/jsf/html">
+</#if>
 
     <nav class="navbar navbar-dark sticky-top bg-dark flex-md-nowrap p-0" role="navigation">
         <h:outputLink styleClass="navbar-brand col-sm-3 col-md-2 me-0 px-3" value="#">

--- a/starter-generator/src/main/resources/template/jsf/home.xhtml.ftl
+++ b/starter-generator/src/main/resources/template/jsf/home.xhtml.ftl
@@ -38,9 +38,15 @@
     holder.
 -->
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
+<#if model.importPrefix == "jakarta" >
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:f="jakarta.faces.core"
                 xmlns:h="jakarta.faces.html"
+ <#else>
+                xmlns:ui="http://java.sun.com/jsf/facelets"
+                xmlns:f="http://java.sun.com/jsf/core"
+                xmlns:h="http://java.sun.com/jsf/html"
+</#if>
                 template="/WEB-INF/layout/template.xhtml">
 
     <ui:define name="pageTitle">Home</ui:define>

--- a/starter-generator/src/main/resources/template/jsf/template.xhtml.ftl
+++ b/starter-generator/src/main/resources/template/jsf/template.xhtml.ftl
@@ -40,9 +40,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:ui="jakarta.faces.facelets"
-      xmlns:f="jakarta.faces.core"
-      xmlns:h="jakarta.faces.html">
+<#if model.importPrefix == "jakarta" >
+                xmlns:ui="jakarta.faces.facelets"
+                xmlns:f="jakarta.faces.core"
+                xmlns:h="jakarta.faces.html">
+ <#else>
+                xmlns:ui="http://java.sun.com/jsf/facelets"
+                xmlns:f="http://java.sun.com/jsf/core"
+                xmlns:h="http://java.sun.com/jsf/html">
+</#if>
     <f:view contentType="text/html" encoding="UTF-8">
         <ui:insert name="metadata"></ui:insert>
         <h:head>

--- a/starter-generator/src/main/resources/template/repository/EntityRepository.java.ftl
+++ b/starter-generator/src/main/resources/template/repository/EntityRepository.java.ftl
@@ -20,7 +20,6 @@ package ${package};
 import ${model.importPrefix}.persistence.EntityManager;
 import ${model.importPrefix}.inject.Inject;
 import ${EntityClass_FQN};
-<#if EntityPKClass_FQN!="">import ${EntityPKClass_FQN};</#if>
 
 <#if cdi>@Dependent</#if><#if !cdi>@Stateless</#if>
 <#if named>@Named("${entityInstance}")</#if>

--- a/starter-ui/src/main/webapp/assets/main.js
+++ b/starter-ui/src/main/webapp/assets/main.js
@@ -90,10 +90,13 @@ formInputs.forEach((input, index) => {
 form.addEventListener('submit', function (event) {
     event.preventDefault();
 
+    const form = event.target;
+    const submitButton = form.querySelector('button[type="submit"]');
+    submitButton.disabled = true;
+    submitButton.classList.add('button--disabled');
     document.getElementById('loadingBar').style.display = 'block';
     document.getElementById('loadingBar').scrollIntoView({behavior: 'smooth'});
 
-    const form = event.target;
     const formData = new FormData(form);
     const jsonObject = {};
     formInputs.forEach((input) => {
@@ -108,8 +111,8 @@ form.addEventListener('submit', function (event) {
             }
         } else {
             jsonObject[key] = input.value;
-            if(input.id == 'erDiagram' && !$("#mermaidErDiagramList").val()) {
-                 jsonObject[key] = '';
+            if (input.id == 'erDiagram' && !$("#mermaidErDiagramList").val()) {
+                jsonObject[key] = '';
             }
         }
     });
@@ -128,6 +131,8 @@ form.addEventListener('submit', function (event) {
                     return response.blob();
                 } else {
                     alert('Error generating application. Please try again.');
+                    submitButton.disabled = false;
+                    submitButton.classList.remove('button--disabled');
                 }
             })
             .then(blob => {
@@ -143,11 +148,15 @@ form.addEventListener('submit', function (event) {
                 a.click();
 
                 window.URL.revokeObjectURL(url);
+                submitButton.disabled = false;
+                submitButton.classList.remove('button--disabled');
             })
             .catch(error => {
                 document.getElementById('loadingBar').style.display = 'none';
                 console.error('Error:', error);
                 alert('An error occurred while generating the application.');
+                submitButton.disabled = false;
+                submitButton.classList.remove('button--disabled');
             });
 });
 

--- a/starter-ui/src/main/webapp/index.html
+++ b/starter-ui/src/main/webapp/index.html
@@ -456,7 +456,7 @@
                                                             <select class="form__select" id="generateWeb" name="generateWeb" title="Generate Web code">
                                                               <option value="none">None</option>
                                                               <option value="html">HTML</option>
-                                                              <option value="jsf" selected>JSF</option>
+                                                              <option value="jsf" selected>Jakarta Faces</option>
                                                             </select>
                                                         </p>
 


### PR DESCRIPTION


This PR adds support for generating JSF applications from an ER diagram, with handling of relationship attributes.

### Supported Relationships
- `@OneToOne`
- `@ManyToOne`

### How to Test
1. Open the **Payara Starter** page.
2. Select **ER Diagram** as the input source.
3. In the **Web** section, choose **JSF**.
4. Click **Generate** to create the application.

This update enhances the generated JSF UI by reflecting entity relationships, improving developer experience and application completeness.
