### PR TITLE
FISH-10970 Jakarta EE 11 support in Payara Starter

### DIFF
--- a/starter-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/starter-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -29,7 +29,7 @@ private void validateInput(String profile, String jakartaEEVersion, String javaV
     boolean deleteDirectory = true;
 
     if (!isValidJakartaEEVersion(jakartaEEVersion)) {
-        throwAndDelete("Failed, valid Jakarta EE versions are 8, 9, 9.1, and 10", outputDirectory);
+        throwAndDelete("Failed, valid Jakarta EE versions are 8, 9, 9.1, 10 and 11", outputDirectory);
     }
 
     if (!isValidProfile(profile)) {
@@ -44,8 +44,8 @@ private void validateInput(String profile, String jakartaEEVersion, String javaV
         throwAndDelete("Failed, valid platform values are server and micro", outputDirectory);
     }
 
-    if (profile.equalsIgnoreCase("core") && !jakartaEEVersion.equals("10")) {
-        throwAndDelete("Failed, the Core Profile is only supported for Jakarta EE 10", outputDirectory);
+    if (profile.equalsIgnoreCase("core") && !(jakartaEEVersion.equals("10") || jakartaEEVersion.equals("11"))) {
+        throwAndDelete("Failed, the Core Profile is only supported for Jakarta EE 10 and 11", outputDirectory);
     }
 
     if (!jakartaEEVersion.equals("8") && javaVersion.equals("8")) {
@@ -54,7 +54,7 @@ private void validateInput(String profile, String jakartaEEVersion, String javaV
 }
 
 private boolean isValidJakartaEEVersion(String version) {
-    return version.equals("8") || version.equals("9") || version.equals("9.1") || version.equals("10");
+    return version.equals("8") || version.equals("9") || version.equals("9.1") || version.equals("10") || version.equals("11");
 }
 
 private boolean isValidProfile(String profile) {

--- a/starter-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/starter-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -62,7 +62,7 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
         </requiredProperty>
         <requiredProperty key="jakartaEEVersion">
             <defaultValue>10</defaultValue>
-            <validationRegex>^(8|9|9.1|10)$</validationRegex>
+            <validationRegex>^(8|9|9.1|10|11)$</validationRegex>
         </requiredProperty>
         <requiredProperty key="profile">
             <defaultValue>full</defaultValue>

--- a/starter-archetype/src/main/resources/archetype-resources/build.gradle
+++ b/starter-archetype/src/main/resources/archetype-resources/build.gradle
@@ -1,4 +1,6 @@
-#if (${jakartaEEVersion} == '10')
+#if (${jakartaEEVersion} == '11')
+    #set ($eeApiVersion = "11.0.0")
+#elseif (${jakartaEEVersion} == '10')
     #set ($eeApiVersion = "10.0.0")
 #elseif (${jakartaEEVersion} == '9.1')
     #set ($eeApiVersion = "9.1.0")

--- a/starter-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/starter-archetype/src/main/resources/archetype-resources/pom.xml
@@ -1,4 +1,6 @@
-#if (${jakartaEEVersion} == '10')
+#if (${jakartaEEVersion} == '11')
+    #set ($eeApiVersion = "11.0.0")
+#elseif (${jakartaEEVersion} == '10')
     #set ($eeApiVersion = "10.0.0")
 #elseif (${jakartaEEVersion} == '9.1')
     #set ($eeApiVersion = "9.1.0")

--- a/starter-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/web.xml
+++ b/starter-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/web.xml
@@ -10,6 +10,10 @@
 #set ($webAppVersion = "6.0")
 #set ($xmlns = "https://jakarta.ee/xml/ns/jakartaee")
 #set ($schemaLocation = "https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd")
+#elseif (${jakartaEEVersion} == '11')
+#set ($webAppVersion = "7.0")
+#set ($xmlns = "https://jakarta.ee/xml/ns/jakartaee")
+#set ($schemaLocation = "https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_7_0.xsd")
 #end
 <web-app version="$webAppVersion"
          xmlns="$xmlns"

--- a/starter-generator/src/main/resources/template/jsf/entity.xhtml.ftl
+++ b/starter-generator/src/main/resources/template/jsf/entity.xhtml.ftl
@@ -11,70 +11,68 @@
                 template="/WEB-INF/layout/template.xhtml">
 
     <ui:define name="content">
-        <h:form>
-            <h3>${entity.getTitle()}</h3>
-            <p>${entity.getDescription()}</p>
-            <h:panelGrid columns="2" columnClasses="label,value" styleClass="table-form">
-            <#list entity.attributes as attribute>
-            <#if !(attribute.primaryKey && attribute.type != "String") && !attribute.multi>
-                <#assign attrId = attribute.getName()>
-                <#assign attrValue = beanName + '.' + entityNameLowerCase + '.' + attribute.name>
+        <h3>${entity.getTitle()}</h3>
+        <p>${entity.getDescription()}</p>
+        <h:panelGrid columns="2" columnClasses="label,value" styleClass="table-form">
+        <#list entity.attributes as attribute>
+        <#if !(attribute.primaryKey && attribute.type != "String") && !attribute.multi>
+            <#assign attrId = attribute.getName()>
+            <#assign attrValue = beanName + '.' + entityNameLowerCase + '.' + attribute.name>
 
-                <h:outputLabel for="${attrId}" value="${attribute.getStartCaseName()}:" />
-                <#if model.getEntity(attribute.type)??>
-                <h:selectOneMenu id="${attrId}"
-                                 value="${'#{' + attrValue + '}'}"
-                                 converter="${attribute.converter}">
-                    <f:selectItem itemLabel="Select ${attribute.titleCaseName}" noSelectionOption="true" />
-                    <f:selectItems value="${'#{' + attribute.bean + '.all' + attribute.pluralType + '}'}"
-                                   var="${attrId}"
-                                   itemValue="${'#{' + attrId + '}'}"
-                                   itemLabel="${'#{' + attrId + '}'}" />
-                </h:selectOneMenu>
-                <#elseif attribute.type == "LocalDateTime" || attribute.type == "LocalDate">
-                <h:inputText id="${attrId}" 
-                             value="${'#{' + attrValue + '}'}" 
+            <h:outputLabel for="${attrId}" value="${attribute.getStartCaseName()}:" />
+            <#if model.getEntity(attribute.type)??>
+            <h:selectOneMenu id="${attrId}"
+                             value="${'#{' + attrValue + '}'}"
                              converter="${attribute.converter}">
-                    <f:passThroughAttribute name="type" value="${(attribute.type == 'LocalDateTime')?string('datetime-local', 'date')}" />
-                </h:inputText>
-                <#elseif attribute.isNumber()>
-                <h:inputText id="${attrId}" value="${'#{' + attrValue + '}'}" >
-                    <f:passThroughAttribute name="type" value="number" />
-                </h:inputText>
-                <#else>
-                <h:inputText id="${attrId}" value="${'#{' + attrValue + '}'}" />
-                </#if>
+                <f:selectItem itemLabel="Select ${attribute.titleCaseName}" noSelectionOption="true" />
+                <f:selectItems value="${'#{' + attribute.bean + '.all' + attribute.pluralType + '}'}"
+                               var="${attrId}"
+                               itemValue="${'#{' + attrId + '}'}"
+                               itemLabel="${'#{' + attrId + '}'}" />
+            </h:selectOneMenu>
+            <#elseif attribute.type == "LocalDateTime" || attribute.type == "LocalDate">
+            <h:inputText id="${attrId}" 
+                         value="${'#{' + attrValue + '}'}" 
+                         converter="${attribute.converter}">
+                <f:passThroughAttribute name="type" value="${(attribute.type == 'LocalDateTime')?string('datetime-local', 'date')}" />
+            </h:inputText>
+            <#elseif attribute.isNumber()>
+            <h:inputText id="${attrId}" value="${'#{' + attrValue + '}'}" >
+                <f:passThroughAttribute name="type" value="number" />
+            </h:inputText>
+            <#else>
+            <h:inputText id="${attrId}" value="${'#{' + attrValue + '}'}" />
             </#if>
-            </#list>
-            </h:panelGrid>
-            <#list entity.attributes as attribute>
-            <#if attribute.primaryKey && attribute.type != "String">
-            <h:inputHidden id="${attribute.getName()}" 
-                           value="${'#' + '{'+ beanName + '.' + entityNameLowerCase + '.' + attribute.name + '}'}" />
+        </#if>
+        </#list>
+        </h:panelGrid>
+        <#list entity.attributes as attribute>
+        <#if attribute.primaryKey && attribute.type != "String">
+        <h:inputHidden id="${attribute.getName()}" 
+                       value="${'#' + '{'+ beanName + '.' + entityNameLowerCase + '.' + attribute.name + '}'}" />
+        </#if>
+        </#list>
+
+        <h:commandButton value="Save" action="${'#' + '{'+ beanName + '.save}'}" styleClass="btn btn-primary mt-3" />
+
+        <h3 class="mt-5">${entity.getTitle()} List</h3>
+        <h:dataTable value="${'#' + '{'+ beanName + '.all'+entityNameTitleCasePluralize+'}'}" var="${entityNameLowerCase}" border="1" styleClass="table table-striped table-bordered">
+        <#list entity.attributes as attribute>
+            <#if !attribute.multi>
+            <h:column>
+                <f:facet name="header">${attribute.getStartCaseName()}</f:facet>
+                ${'#' + '{' + entityNameLowerCase + '.' + attribute.name + '}'}
+            </h:column>
             </#if>
-            </#list>
-
-            <h:commandButton value="Save" action="${'#' + '{'+ beanName + '.save}'}" styleClass="btn btn-primary mt-3" />
-
-            <h3 class="mt-5">${entity.getTitle()} List</h3>
-            <h:dataTable value="${'#' + '{'+ beanName + '.all'+entityNameTitleCasePluralize+'}'}" var="${entityNameLowerCase}" border="1" styleClass="table table-striped table-bordered">
-            <#list entity.attributes as attribute>
-                <#if !attribute.multi>
-                <h:column>
-                    <f:facet name="header">${attribute.getStartCaseName()}</f:facet>
-                    ${'#' + '{' + entityNameLowerCase + '.' + attribute.name + '}'}
-                </h:column>
-                </#if>
-            </#list>
-                <h:column>
-                    <f:facet name="header">Actions</f:facet>
-                    <h:commandLink value="Edit" action="${'#' + '{'+ beanName + '.edit(' + entityNameLowerCase + ')}'}" styleClass="btn btn-link p-0" />
-                    |
-                    <h:commandLink value="Delete" action="${'#' + '{'+ beanName + '.remove(' + entityNameLowerCase + '.' + pkName + ')}'}"
-                                   onclick="return confirm('Delete this ${entityNameLowerCase}?');" 
-                                   styleClass="btn btn-link p-0 text-danger" />
-                </h:column>
-            </h:dataTable>
-        </h:form>
+        </#list>
+            <h:column>
+                <f:facet name="header">Actions</f:facet>
+                <h:commandLink value="Edit" action="${'#' + '{'+ beanName + '.edit(' + entityNameLowerCase + ')}'}" styleClass="btn btn-link p-0" />
+                |
+                <h:commandLink value="Delete" action="${'#' + '{'+ beanName + '.remove(' + entityNameLowerCase + '.' + pkName + ')}'}"
+                               onclick="return confirm('Delete this ${entityNameLowerCase}?');" 
+                               styleClass="btn btn-link p-0 text-danger" />
+            </h:column>
+        </h:dataTable>
     </ui:define>
 </ui:composition>

--- a/starter-ui/src/main/webapp/assets/main.js
+++ b/starter-ui/src/main/webapp/assets/main.js
@@ -162,8 +162,9 @@ form.addEventListener('submit', function (event) {
 
 
 // Define the order of Jakarta EE versions
-const jakartaEEVersionOrder = ["10", "9.1", "9", "8"];
+const jakartaEEVersionOrder = ["11", "10", "9.1", "9", "8"];
 const jakartaVersions = {
+    "11": "Jakarta EE 11",
     "10": "Jakarta EE 10",
     "9.1": "Jakarta EE 9.1",
     "9": "Jakarta EE 9",
@@ -199,6 +200,7 @@ function populateSelect(selectId, optionOrder, optionMap) {
 // Call the function to populate the select elements
 populateSelect('jakartaEEVersion', jakartaEEVersionOrder, jakartaVersions);
 populateSelect('javaVersion', Object.keys(javaVersions), javaVersions);
+jakartaEEVersionSelect.value = '10';
 
 // Function to fetch Payara versions and populate the dropdown
 function populatePayaraVersionsDropdown(jakartaEEVersion) {


### PR DESCRIPTION
This PR adds support for **Jakarta EE 11** in Payara Starter.

### Details
- Jakarta EE 11 is now available as a selectable option when generating a new project.
- **Jakarta EE 10** remains the **default selected version** to ensure stability until a stable release of **Payara Community 7** is available.
- **Alpha versions are filtered out** for all Payara series **except 7.x**, as stable community releases are not yet available for newer versions.

### Note
This change enables early access to Jakarta EE 11 for testing and exploration, while preserving a stable default experience.