### PR TITLE
FISH-11602 Fixed background disappearing on popup

### DIFF
--- a/starter-ui/src/main/webapp/index.html
+++ b/starter-ui/src/main/webapp/index.html
@@ -672,24 +672,26 @@
                         </blinky-toggle-button>
                     </div>
                 </div>
-                <button class="button button--clear close">
+            </div>
+            <button class="button button--small close">
+                <span class="button__text">
                     <svg class="icon" width="1em" height="1em" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
                         <use href="ui/images/icons.svg#icon-cross"></use>
                     </svg>
                     <span class="visually-hidden">Close ER Designer</span>
-                </button>
-            </div>
+                </span>
+            </button>
         </div>
         <script>
                 function toggleDiagramView() {
                     const diagramView = document.getElementById('diagramView');
                     const diagramSource = document.getElementById('diagramSource');
                     const makeFullscreen = diagramView.style.width !== '100%';
-                    diagramView.style.width = makeFullscreen ? '100%' : '50%';
-                    diagramSource.style.width = makeFullscreen ? '0%' : '50%';
+                    diagramView.style.width = makeFullscreen ? '100%' : '';
+                    diagramSource.style.width = makeFullscreen ? '0%' : '';
                     document.getElementById('queryBox').style.display = makeFullscreen ? 'none' : 'inline';
                     document.getElementById('queryBoxHidden').style.display = makeFullscreen ? 'inline' : 'none';
-                    diagramSource.style.display = makeFullscreen ? 'none' : 'inline';
+                    diagramSource.style.display = makeFullscreen ? 'none' : '';
                 }
         </script>
         <script>

--- a/starter-ui/src/main/webapp/ui-starter/er-designer.css
+++ b/starter-ui/src/main/webapp/ui-starter/er-designer.css
@@ -54,7 +54,6 @@ button:disabled {
 	top: 0;
 	width: 100%;
 	height: 100%;
-	overflow: auto;
 	background-color: rgba(var(--onyx), 0.9);
 	padding: var(--padding);
 }
@@ -69,12 +68,50 @@ button:disabled {
 	position: relative;
 }
 
+/* Set both columns in the ERD as flex so we can have the middle items (code and SVG preview) take up any available space or kick in a scroll on shorter screens. */
+.card.half {
+	display: flex;
+	flex-direction: column;
+	flex-shrink: 1;
+}
+/* Keep the titles and footer to only the size they need. */
+.title-container,
+.inline-elements {
+	flex: 0 1 auto;
+}
+/* Stretch the code and SVG preview items. We add a min-height as an absolute fallback for smaller screens, it get's ignored on wider screens so it doesn't hurt to include at this point.  */
+.CodeMirror,
+.livePreview {
+	flex: 1 1 1vh;
+	min-height: 20vh;
+}
+.CodeMirror-scroll {
+	min-height: 20vh;
+}
+/* Smaller width screens, whcih off the vertical scrolling on the code and SVG preview items, we now need the whole popup to scroll and we don't want an awful multiple scrolling to happen. */
+@media (max-width: 700px) {
+	.modal-content {
+		display: block;
+		flex-flow: column;
+		overflow: auto;
+	}
+	/* Easiest way to clear the flex scrolling. */
+	.card.half {
+		display: block;
+	}
+	/* Unset the default coming in from the main codemirror CSS, there's no point setting a min height on mobile and thus forcing users to scroll over an empty code item. */
+	.CodeMirror {
+		height: auto;
+	}
+}
+
 .close {
 	display: block;
 	margin: 0;
 	position: absolute;
-	right: 0;
-	top: 0;
+	right: calc(var(--padding) + 0.4rem);
+	top: calc(var(--padding) + 0.4rem);
+	padding: 0;
 }
 
 .title-container {
@@ -83,8 +120,8 @@ button:disabled {
 
 #livePreview {
 	border: 1px solid var(--form-field-border);
-	height: 82%;
 	margin-bottom: var(--gutter);
+	overflow: auto
 }
 
 #sourceCode {
@@ -110,7 +147,6 @@ button:disabled {
 }
 
 .CodeMirror {
-	height: 82%;
 	font-size: small;
 	border: 1px solid var(--form-field-border);
 	margin-bottom: var(--gutter);


### PR DESCRIPTION
Not technically a background issue, is was a symptom of another issue to do with scrolling in popups. I've made the following changes:

- Removed the scroll on the entire popup and moved it to the code panel and the SVG preview, now on larger screens each panel can scroll separately as needed
- Moved the close button to outside of the scrolling panel HTML so it won't scroll off the screen on smaller screens
- Swapped the close button to one with a background as now the content can scroll underneath it
- For smaller screens...
  - Flipped the CSS flex to stack the code and SVG columns, removed their individual scrolls, and applied the scroll to the popup content as a whole
  - Removed hardcoded heights from the code and SVG previews so as not to bombard the user with nasty nested scrolls where they make no sense
- Adjusted the ER Designer fullscreen toggle to not set inlined CSS directly on the HTML elements when switching back to the non-fullscreen option as these values are now CSS query dependent

See Jira task for screenshots.