### PR TITLE
FISH-9870  Fix build failures by detecting missing Payara JDK-specific Docker tags and falling back to base image tags automatically

### DIFF
--- a/starter-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/starter-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -37,7 +37,7 @@ private void validateInput(String profile, String jakartaEEVersion, String javaV
     }
 
     if (!isValidJavaVersion(javaVersion)) {
-        throwAndDelete("Failed, valid Java SE versions are 8, 11, 17, and 21", outputDirectory);
+        throwAndDelete("Failed, valid Java SE versions are 8, 11, 17, 21, and 25", outputDirectory);
     }
 
     if (!isValidPlatform(platform)) {
@@ -62,7 +62,7 @@ private boolean isValidProfile(String profile) {
 }
 
 private boolean isValidJavaVersion(String version) {
-    return version.equals("8") || version.equals("11") || version.equals("17") || version.equals("21");
+    return version.equals("8") || version.equals("11") || version.equals("17") || version.equals("21") || version.equals("25");
 }
 
 private boolean isValidPlatform(String platform) {

--- a/starter-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/starter-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -70,7 +70,7 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
         </requiredProperty>
         <requiredProperty key="javaVersion">
             <defaultValue>17</defaultValue>
-            <validationRegex>^(8|11|17|21)$</validationRegex>
+            <validationRegex>^(8|11|17|21|25)$</validationRegex>
         </requiredProperty>
         <requiredProperty key="platform">
             <defaultValue>server</defaultValue>
@@ -151,6 +151,10 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
         <requiredProperty key="generateWeb">
             <defaultValue>none</defaultValue>
             <validationRegex>^(none|jsf|html)$</validationRegex>
+        </requiredProperty>
+        <requiredProperty key="dockerJdkTagSupported">
+            <defaultValue>true</defaultValue>
+            <validationRegex>^(false|true)$</validationRegex>
         </requiredProperty>
     </requiredProperties>
 

--- a/starter-archetype/src/main/resources/archetype-resources/Dockerfile
+++ b/starter-archetype/src/main/resources/archetype-resources/Dockerfile
@@ -6,41 +6,28 @@
 #end
 #end
 #if (${platform} == 'server')
-#if (${javaVersion} == '21')
 #if (${profile} == 'full')
-#set ($baseImage = "payara/server-full:${payaraVersion}-jdk21")
+#set ($imageRepo = "payara/server-full")
 #else
-#set ($baseImage = "payara/server-web:${payaraVersion}-jdk21")
-#end
-#elseif (${javaVersion} == '17')
-#if (${profile} == 'full')
-#set ($baseImage = "payara/server-full:${payaraVersion}-jdk17")
-#else
-#set ($baseImage = "payara/server-web:${payaraVersion}-jdk17")
-#end
-#elseif (${javaVersion} == '11')
-#if (${profile} == 'full')
-#set ($baseImage = "payara/server-full:${payaraVersion}-jdk11")
-#else
-#set ($baseImage = "payara/server-web:${payaraVersion}-jdk11")
-#end
-#else
-#if (${profile} == 'full')
-#set ($baseImage = "payara/server-full:${payaraVersion}")
-#else
-#set ($baseImage = "payara/server-web:${payaraVersion}")
-#end
+#set ($imageRepo = "payara/server-web")
 #end
 #elseif (${platform} == 'micro')
-#if (${javaVersion} == '21')
-#set ($baseImage = "payara/micro:${payaraVersion}-jdk21")
-#elseif (${javaVersion} == '17')
-#set ($baseImage = "payara/micro:${payaraVersion}-jdk17")
-#elseif (${javaVersion} == '11')
-#set ($baseImage = "payara/micro:${payaraVersion}-jdk11")
-#else
-#set ($baseImage = "payara/micro:${payaraVersion}")
+#set ($imageRepo = "payara/micro")
 #end
+#if (${dockerJdkTagSupported} == 'true')
+#if (${javaVersion} == '25')
+#set ($baseImage = "${imageRepo}:${payaraVersion}-jdk25")
+#elseif (${javaVersion} == '21')
+#set ($baseImage = "${imageRepo}:${payaraVersion}-jdk21")
+#elseif (${javaVersion} == '17')
+#set ($baseImage = "${imageRepo}:${payaraVersion}-jdk17")
+#elseif (${javaVersion} == '11')
+#set ($baseImage = "${imageRepo}:${payaraVersion}-jdk11")
+#else
+#set ($baseImage = "${imageRepo}:${payaraVersion}")
+#end
+#else
+#set ($baseImage = "${imageRepo}:${payaraVersion}")
 #end
 #if (${build} == 'maven')
 #set ($artifactParentDir = "target")

--- a/starter-ui/src/main/java/fish/payara/starter/resources/ApplicationConfiguration.java
+++ b/starter-ui/src/main/java/fish/payara/starter/resources/ApplicationConfiguration.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2023-2024 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2026 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -193,7 +193,7 @@ public class ApplicationConfiguration {
     }
 
     public String getArtifactId() {
-        return artifactId;
+        return StringUtil.toKebabCase(artifactId);
     }
 
     public void setArtifactId(String artifactId) {

--- a/starter-ui/src/main/java/fish/payara/starter/resources/ApplicationConfiguration.java
+++ b/starter-ui/src/main/java/fish/payara/starter/resources/ApplicationConfiguration.java
@@ -77,6 +77,7 @@ public class ApplicationConfiguration {
     public static final String ER_DIAGRAM_NAME = "erDiagramName";
     public static final String REST_SUBPACKAGE = "restSubpackage";
     public static final String GENERATE_WEB = "generateWeb";
+    public static final String DOCKER_JDK_TAG_SUPPORTED = "dockerJdkTagSupported";
 
     public static final String PAYARA_VERSION_6_2023_11 = "6.2023.11";
 

--- a/starter-ui/src/main/java/fish/payara/starter/resources/ApplicationGenerator.java
+++ b/starter-ui/src/main/java/fish/payara/starter/resources/ApplicationGenerator.java
@@ -46,6 +46,7 @@ import static fish.payara.starter.resources.ApplicationConfiguration.ADD_PAYARA_
 import static fish.payara.starter.resources.ApplicationConfiguration.ARTIFACT_ID;
 import static fish.payara.starter.resources.ApplicationConfiguration.AUTH;
 import static fish.payara.starter.resources.ApplicationConfiguration.BUILD;
+import static fish.payara.starter.resources.ApplicationConfiguration.DOCKER_JDK_TAG_SUPPORTED;
 import static fish.payara.starter.resources.ApplicationConfiguration.DOCKER;
 import static fish.payara.starter.resources.ApplicationConfiguration.GENERATE_WEB;
 import static fish.payara.starter.resources.ApplicationConfiguration.GROUP_ID;
@@ -119,6 +120,9 @@ public class ApplicationGenerator {
 
     @Inject
     private LangChainChatService langChainChatService;
+
+    @Inject
+    private DockerImageTagService dockerImageTagService;
 
     public Future<File> generate(ApplicationConfiguration appProperties) {
         return executorService.submit(() -> {
@@ -222,6 +226,9 @@ public class ApplicationGenerator {
         properties.put(AUTH, appProperties.getAuth());
         properties.put(REST_SUBPACKAGE, appProperties.getRestSubpackage());
         properties.put(GENERATE_WEB, appProperties.getGenerateWeb());
+        boolean jdkTagSupported = dockerImageTagService.isJdkTagAvailable(
+                appProperties.getPayaraVersion(), appProperties.getJavaVersion());
+        properties.put(DOCKER_JDK_TAG_SUPPORTED, jdkTagSupported);
         return properties;
     }
 

--- a/starter-ui/src/main/java/fish/payara/starter/resources/DockerImageTagService.java
+++ b/starter-ui/src/main/java/fish/payara/starter/resources/DockerImageTagService.java
@@ -1,0 +1,117 @@
+/*
+ *
+ * Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.starter.resources;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Service that checks Docker Hub tag availability for Payara images.
+ * Results are cached to avoid repeated network calls.
+ */
+@ApplicationScoped
+public class DockerImageTagService {
+
+    private static final Logger LOGGER = Logger.getLogger(DockerImageTagService.class.getName());
+    private static final String DOCKER_HUB_TAG_URL = "https://hub.docker.com/v2/repositories/payara/micro/tags/%s";
+    private static final long CACHE_TTL_MILLIS = TimeUnit.HOURS.toMillis(24);
+
+    private final Map<String, CachedResult> tagCache = new ConcurrentHashMap<>();
+
+    /**
+     * Checks whether a JDK-specific Docker image tag exists for the given
+     * Payara version and Java version (e.g. {@code 6.2024.9-jdk11}).
+     *
+     * @param payaraVersion the Payara version string (e.g. {@code 6.2024.9})
+     * @param javaVersion   the Java version (e.g. {@code 11}, {@code 17}, {@code 21})
+     * @return {@code true} if the tag exists on Docker Hub, {@code false} otherwise
+     */
+    public boolean isJdkTagAvailable(String payaraVersion, int javaVersion) {
+        String tag = payaraVersion + "-jdk" + javaVersion;
+        CachedResult cached = tagCache.get(tag);
+        if (cached != null && !cached.isExpired()) {
+            return cached.exists;
+        }
+        boolean exists = fetchTagExists(tag);
+        tagCache.put(tag, new CachedResult(exists));
+        return exists;
+    }
+
+    private boolean fetchTagExists(String tag) {
+        String urlStr = String.format(DOCKER_HUB_TAG_URL, tag);
+        try {
+            URL url = new URL(urlStr);
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("GET");
+            connection.setConnectTimeout(5000);
+            connection.setReadTimeout(5000);
+            int responseCode = connection.getResponseCode();
+            connection.disconnect();
+            boolean exists = responseCode == HttpURLConnection.HTTP_OK;
+            LOGGER.log(Level.FINE, "Docker Hub tag {0} exists: {1}", new Object[]{tag, exists});
+            return exists;
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, "Failed to check Docker Hub tag availability for {0}, assuming tag exists: {1}",
+                    new Object[]{tag, e.getMessage()});
+            return true;
+        }
+    }
+
+    private static class CachedResult {
+
+        final boolean exists;
+        final long timestamp;
+
+        CachedResult(boolean exists) {
+            this.exists = exists;
+            this.timestamp = System.currentTimeMillis();
+        }
+
+        boolean isExpired() {
+            return System.currentTimeMillis() - timestamp > CACHE_TTL_MILLIS;
+        }
+    }
+}

--- a/starter-ui/src/main/java/fish/payara/starter/resources/StringUtil.java
+++ b/starter-ui/src/main/java/fish/payara/starter/resources/StringUtil.java
@@ -1,0 +1,63 @@
+/*
+ *
+ * Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.starter.resources;
+
+/**
+ *
+ * @author Gaurav Gupta
+ */
+public class StringUtil {
+    public static void main(String[] args) {
+        System.out.println(toKebabCase("ramSita"));
+        System.out.println(toKebabCase("ra-mSita"));
+        System.out.println(toKebabCase("ram-Sita"));
+        System.out.println(toKebabCase("ramS-ita"));
+    }
+
+    public static String toKebabCase(String input) {
+        if (input == null || input.isEmpty()) {
+            return input;
+        }
+
+        return input
+                .replaceAll("([a-z])([A-Z])", "$1-$2") // split camelCase
+                .replaceAll("([A-Z])([A-Z][a-z])", "$1-$2") // handle cases like HTTPServer
+                .toLowerCase();
+    }
+}

--- a/starter-ui/src/main/webapp/assets/main.js
+++ b/starter-ui/src/main/webapp/assets/main.js
@@ -172,6 +172,7 @@ const jakartaVersions = {
 };
 
 const javaVersions = {
+    "25": "Java SE 25",
     "21": "Java SE 21",
     "17": "Java SE 17",
     "11": "Java SE 11",
@@ -276,6 +277,9 @@ function listJavaVersionOption() {
     } else {
         if (compareVersion(payaraVersion, '6.2023.11') > 0) {
             // Payara version is greater than '6.2023.11'
+            if (payaraVersion.startsWith('7.')) {
+                addJavaVersionOption('25', 'Java SE 25');
+            }
             addJavaVersionOption('21', 'Java SE 21');
         }
         addJavaVersionOption('17', 'Java SE 17');


### PR DESCRIPTION
Fix Docker image build failure when JDK-specific tag is missing

- Fixed build failure caused by unavailable Docker tags (e.g. `6.2024.9-jdk11`).
- Added `DockerImageTagService` to dynamically check if a JDK-specific Payara image tag exists on Docker Hub.
- Introduced `dockerJdkTagSupported` flag to control tag selection during project generation.
- Updated Dockerfile logic to:
  - Use -jdk<version> tag when available
  - Fallback to base ${payaraVersion} tag when not
- Implemented caching (24h TTL) and safe fallback to avoid network-related build disruptions.
- Prevents invalid Docker image references and ensures reliable builds across Payara versions.
- Listed JDK 25 in UI