### PR TITLE
FISH-11346: Escape Java reserved keywords in generated resource parameter names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /starter-generator/target/
 starter-ui/nb-configuration.xml
 starter-ui/nb-configuration.xml
+.claude/settings.local.json

--- a/starter-generator/src/main/java/fish/payara/starter/application/generator/CRUDAppGenerator.java
+++ b/starter-generator/src/main/java/fish/payara/starter/application/generator/CRUDAppGenerator.java
@@ -60,6 +60,7 @@ import fish.payara.starter.application.domain.Attribute;
 import static fish.payara.starter.application.util.AttributeType.isBoolean;
 import static fish.payara.starter.application.util.AttributeType.isPrimitive;
 import static fish.payara.starter.application.util.JPAUtil.ALL_RESERVED_KEYWORDS;
+import static fish.payara.starter.application.util.JavaUtil.escapeJavaIdentifier;
 import static fish.payara.starter.application.util.JavaUtil.getIntrospectionPrefix;
 import static fish.payara.starter.application.util.JavaUtil.getMethodName;
 import static fish.payara.starter.application.util.StringUtils.firstLower;
@@ -681,7 +682,7 @@ public class CRUDAppGenerator {
         dataModel.put("entity", entity);
         dataModel.put("entityTranslationKey", entityInstance);
         dataModel.put("instanceType", entity.getClassName());
-        dataModel.put("instanceName", entityInstance);
+        dataModel.put("instanceName", escapeJavaIdentifier(entityInstance));
 
         dataModel.put("model", model);
         dataModel.put("entityNameLowerCase", entity.getLowerCaseName());

--- a/starter-generator/src/main/java/fish/payara/starter/application/generator/CRUDAppGenerator.java
+++ b/starter-generator/src/main/java/fish/payara/starter/application/generator/CRUDAppGenerator.java
@@ -398,7 +398,7 @@ public class CRUDAppGenerator {
             if (attributeName.length() < escapedAttributeName.length()) {
                 sbBody.append("    @Column(name = \"").append(escapedAttributeName).append("\")\n");
             }
-            sbBody.append("    private ").append(attribute.getType()).append(" ").append(attribute.getName()).append(";\n\n");
+            sbBody.append("    private ").append(attribute.getType()).append(" ").append(escapeJavaIdentifier(attribute.getName())).append(";\n\n");
             _imports.addAll(attribute.getImports());
         }
 
@@ -406,12 +406,13 @@ public class CRUDAppGenerator {
         for (Attribute attribute : entity.getAttributes()) {
             String type = attribute.getType();
             String name = attribute.getName();
+            String safeName = escapeJavaIdentifier(name);
             String capitalized = name.substring(0, 1).toUpperCase() + name.substring(1);
             sbfunc.append("    public ").append(type).append(" get").append(capitalized).append("() {\n");
-            sbfunc.append("        return ").append(name).append(";\n");
+            sbfunc.append("        return ").append(safeName).append(";\n");
             sbfunc.append("    }\n\n");
-            sbfunc.append("    public void set").append(capitalized).append("(").append(type).append(" ").append(name).append(") {\n");
-            sbfunc.append("        this.").append(name).append(" = ").append(name).append(";\n");
+            sbfunc.append("    public void set").append(capitalized).append("(").append(type).append(" ").append(safeName).append(") {\n");
+            sbfunc.append("        this.").append(safeName).append(" = ").append(safeName).append(";\n");
             sbfunc.append("    }\n\n");
         }
 
@@ -431,7 +432,7 @@ public class CRUDAppGenerator {
             }
         }
         if (primaryKey != null) {
-            String pkName = primaryKey.getName();
+            String pkName = escapeJavaIdentifier(primaryKey.getName());
 
             sbfunc.append("    @Override\n");
             sbfunc.append("    public int hashCode() {\n");
@@ -466,9 +467,9 @@ public class CRUDAppGenerator {
         sbfunc.append("    @Override\n");
         sbfunc.append("    public String toString() {\n");
         if (displayNameAttr != null) {
-            sbfunc.append("        return String.valueOf(").append(displayNameAttr.getName()).append(");\n");
+            sbfunc.append("        return String.valueOf(").append(escapeJavaIdentifier(displayNameAttr.getName())).append(");\n");
         } else {
-            sbfunc.append("        return String.valueOf(").append(primaryKey.getName()).append(");\n");
+            sbfunc.append("        return String.valueOf(").append(escapeJavaIdentifier(primaryKey.getName())).append(");\n");
         }
         sbfunc.append("    }\n\n");
 
@@ -497,7 +498,8 @@ public class CRUDAppGenerator {
         for (Attribute attribute : entity.getAttributes()) {
             String capitalized = attribute.getName().substring(0, 1).toUpperCase() + attribute.getName().substring(1);
             String queryName = entity.getClassName() + ".findBy" + capitalized;
-            String queryString = "SELECT e FROM " + entity.getClassName() + " e WHERE e." + attribute.getName() + " = :" + attribute.getName();
+            String safeName = escapeJavaIdentifier(attribute.getName());
+            String queryString = "SELECT e FROM " + entity.getClassName() + " e WHERE e." + safeName + " = :" + safeName;
             sb.append("    @NamedQuery(name = \"").append(queryName).append("\", query = \"").append(queryString).append("\"),\n");
         }
 
@@ -520,6 +522,14 @@ public class CRUDAppGenerator {
         String secondEntityVar = relationship.getRelationshipVarNameInSecondEntity() != null ? relationship.getRelationshipVarNameInSecondEntity() : firstEntity.toLowerCase();
         String secondEntityVars = pluralize(secondEntityVar);
         secondEntityVar = singularize(secondEntityVar);
+
+        // Preserve the raw lower-case form for DB column naming before escaping for Java identifiers.
+        String secondEntityVarColumn = secondEntityVar;
+
+        firstEntityVar = escapeJavaIdentifier(firstEntityVar);
+        firstEntityVars = escapeJavaIdentifier(firstEntityVars);
+        secondEntityVar = escapeJavaIdentifier(secondEntityVar);
+        secondEntityVars = escapeJavaIdentifier(secondEntityVars);
 
         if (isFirstEntity) {
             switch (relationshipType) {
@@ -567,7 +577,7 @@ public class CRUDAppGenerator {
                     Attribute attribute = new Attribute(secondEntityVar, false, firstEntity);
                     entity.getAttributes().add(attribute);
                     _imports.add(model.getImportPrefix() + ".json.bind.annotation.JsonbTransient");
-                    String joinColumn = "    @JoinColumn(name = \"" + attribute.getName() + "_id\")";
+                    String joinColumn = "    @JoinColumn(name = \"" + secondEntityVarColumn + "_id\")";
                     appendAttribute(sbfunc, sb, attribute, "    @JsonbTransient\n    @OneToOne\n" + joinColumn, _imports, false);
                     break;
                 }
@@ -575,7 +585,7 @@ public class CRUDAppGenerator {
                 case "||--o{": {
                     Attribute attribute = new Attribute(secondEntityVar, false, firstEntity);
                     entity.getAttributes().add(attribute);
-                    String joinColumn = "    @JoinColumn(name = \"" + attribute.getName() + "_id\")";
+                    String joinColumn = "    @JoinColumn(name = \"" + secondEntityVarColumn + "_id\")";
                     appendAttribute(sbfunc, sb, attribute, "    @ManyToOne\n" + joinColumn, _imports, false);
                     break;
                 }
@@ -587,7 +597,7 @@ public class CRUDAppGenerator {
                     entity.getAttributes().add(attribute);
                     _imports.add(model.getImportPrefix() + ".json.bind.annotation.JsonbTransient");
                     _imports.add("java.util.List");
-                    String joinColumn = "    @JoinColumn(name = \"" + secondEntityVar + "_id\")";
+                    String joinColumn = "    @JoinColumn(name = \"" + secondEntityVarColumn + "_id\")";
                     appendAttribute(sbfunc, sb, attribute, "    @JsonbTransient\n    @ManyToMany\n" + joinColumn, _imports, true);
                     break;
                 }
@@ -705,7 +715,7 @@ public class CRUDAppGenerator {
 
         String pkName = entity.getPrimaryKeyName();
         String pkType = entity.getPrimaryKeyType();
-        dataModel.put("pkName", firstLower(pkName));
+        dataModel.put("pkName", escapeJavaIdentifier(firstLower(pkName)));
         dataModel.put("pkGetter", getMethodName(getIntrospectionPrefix(isBoolean(pkType)), pkName));
         dataModel.put("pkSetter", getMethodName("set", pkName));
         dataModel.put("pkType", pkType);

--- a/starter-generator/src/main/java/fish/payara/starter/application/util/JavaUtil.java
+++ b/starter-generator/src/main/java/fish/payara/starter/application/util/JavaUtil.java
@@ -64,10 +64,13 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
 
 /**
@@ -75,6 +78,28 @@ import java.util.function.Predicate;
  * @author Gaurav Gupta
  */
 public class JavaUtil {
+
+    public static final Set<String> JAVA_RESERVED_KEYWORDS = new HashSet<>(Arrays.asList(
+            "abstract", "assert", "boolean", "break", "byte", "case", "catch",
+            "char", "class", "const", "continue", "default", "do", "double",
+            "else", "enum", "extends", "final", "finally", "float", "for",
+            "goto", "if", "implements", "import", "instanceof", "int",
+            "interface", "long", "native", "new", "package", "private",
+            "protected", "public", "return", "short", "static", "strictfp",
+            "super", "switch", "synchronized", "this", "throw", "throws",
+            "transient", "try", "void", "volatile", "while",
+            "true", "false", "null",
+            "_", "yield", "record", "sealed", "non-sealed", "permits", "var"
+    ));
+
+    /**
+     * Returns a valid Java identifier for {@code name}. If {@code name} collides
+     * with a Java reserved keyword (e.g. {@code case}, {@code class}), a single
+     * underscore is appended so the identifier compiles.
+     */
+    public static String escapeJavaIdentifier(String name) {
+        return JAVA_RESERVED_KEYWORDS.contains(name) ? name + "_" : name;
+    }
 
     public static boolean isJava9() {
         return getJavaVersion() >= 9;

--- a/starter-generator/src/main/resources/template/jsf/EntityBean.java.ftl
+++ b/starter-generator/src/main/resources/template/jsf/EntityBean.java.ftl
@@ -32,10 +32,10 @@ public class ${beanClass} implements Serializable {
     @Inject
     private transient ${EntityRepository} ${entityRepository};
 
-    private ${EntityClass} ${entityInstance} = new ${EntityClass}();
+    private ${EntityClass} ${instanceName} = new ${EntityClass}();
 
     public ${EntityClass} get${EntityClass}() {
-        return ${entityInstance};
+        return ${instanceName};
     }
 
     public List<${EntityClass}> getAll${EntityClassPlural}() {
@@ -43,16 +43,16 @@ public class ${beanClass} implements Serializable {
     }
 
     public String create() {
-      
+
         return null;
     }
     public String save() {
-        if (${entityInstance}.${pkGetter}() == null) {
-             ${entityRepository}.create(${entityInstance});
+        if (${instanceName}.${pkGetter}() == null) {
+             ${entityRepository}.create(${instanceName});
         } else {
-             ${entityRepository}.edit(${entityInstance});
+             ${entityRepository}.edit(${instanceName});
         }
-        ${entityInstance} = new ${EntityClass}(); // reset
+        ${instanceName} = new ${EntityClass}(); // reset
         return null;
     }
 
@@ -62,7 +62,7 @@ public class ${beanClass} implements Serializable {
     }
 
     public String edit(${EntityClass} p) {
-        this.${entityInstance} = p;
+        this.${instanceName} = p;
         return null;
     }
 


### PR DESCRIPTION
 Lowercased entity names that collide with Java keywords (e.g. `Case` -> `case`) produced uncompilable JAX-RS resources. Added `escapeJavaIdentifier` in JavaUtil and applied it to the `instanceName` template variable in CRUDAppGenerator so the generated parameter becomes `case_` instead of the reserved `case`.