### PR TITLE
FISH-12522 - remove the steps to install Playwright dependencies

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,8 +65,7 @@ pipeline {
                             }
                             sh '''echo *#*#*#*#*#*#*#*#*#*#*#*#  Testing Payara Starter  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*'''
                             sh '''cd starter-ui'''
-                            sh '''sudo apt-get update --allow-releaseinfo-change'''
-                            sh '''mvn verify -De2e -Dmaven.javadoc.skip=true -Pinstall-deps '''
+                            sh '''mvn verify -De2e -Dmaven.javadoc.skip=true '''
                             }
                         }
                     post {


### PR DESCRIPTION
Jenkins machines now include Playwright dependencies already installed. 
The steps to install them in the job, using apt-get, should not be necessary anymore